### PR TITLE
chore: apply wbfy updates

### DIFF
--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -1,4 +1,4 @@
-以下のコーディング規約を踏まえて、日本語でレビューしてください。
+Review in English based on the following coding standards.
 
 ## Coding Style
 

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -15,6 +15,7 @@ npmPreapprovedPackages:
   - one-way-git-sync
   - next
   - '@next/*'
+  - '@typescript/*'
   - '@oxfmt/*'
   - '@oxlint/*'
   - '@oxlint-tsgolint/*'

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "conventional-changelog-conventionalcommits": "9.3.1",
     "lefthook": "2.1.5",
     "oxfmt": "0.45.0",
-    "oxlint": "^1.60.0",
+    "oxlint": "1.60.0",
     "oxlint-tsgolint": "0.21.0",
     "prettier": "3.8.1",
     "prettier-plugin-java": "2.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3669,7 +3669,7 @@ __metadata:
     date-time: "npm:4.0.0"
     lefthook: "npm:2.1.5"
     oxfmt: "npm:0.45.0"
-    oxlint: "npm:^1.60.0"
+    oxlint: "npm:1.60.0"
     oxlint-tsgolint: "npm:0.21.0"
     prettier: "npm:3.8.1"
     prettier-plugin-java: "npm:2.8.1"
@@ -6413,7 +6413,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"oxlint@npm:^1.60.0":
+"oxlint@npm:1.60.0":
   version: 1.60.0
   resolution: "oxlint@npm:1.60.0"
   dependencies:


### PR DESCRIPTION
## Summary

- Apply the latest `wbfy` generated maintenance updates.
- Add `@typescript/*` to Yarn preapproved packages.
- Pin `oxlint` to `1.60.0` and update the lockfile entry.
- Update the Gemini styleguide review language to English.

## Why

- Keeps repository tooling aligned with the shared `wbfy` automation.
- Avoids manual drift in generated maintenance configuration.

## Testing

- `yarn check-for-ai`
- pre-push hook: `yarn dotenv -- yarn oxlint .`
