### PR TITLE
fix: support legacy decorators in run command

### DIFF
--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -1,4 +1,6 @@
 import * as child_process from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
 
 import type { CommandModule, InferredOptionTypes } from 'yargs';
 
@@ -32,6 +34,7 @@ export const run: CommandModule<unknown, InferredOptionTypes<typeof builder>> = 
     const isRunningOnBun = process.versions.bun;
     const runtime = isRunningOnBun ? 'bun' : 'node';
     const args = isRunningOnBun ? ['--bun'] : ['--no-warnings', '--import', 'tsx'];
+    const tsconfigPath = isRunningOnBun ? undefined : createTsxTsconfig(process.cwd(), file);
     if (argv.watch) {
       args.push('--watch');
     }
@@ -41,10 +44,61 @@ export const run: CommandModule<unknown, InferredOptionTypes<typeof builder>> = 
     if (argv.verbose) {
       console.info(`Running '${runtime} ${runtimeArgs.join(' ')}'`);
     }
-    const ret = child_process.spawnSync(runtime, runtimeArgs, {
-      stdio: 'inherit',
-      env: { ...process.env },
-    });
-    process.exit(ret.status ?? 1);
+    let status = 1;
+    try {
+      const ret = child_process.spawnSync(runtime, runtimeArgs, {
+        stdio: 'inherit',
+        env: { ...process.env, ...(tsconfigPath ? { TSX_TSCONFIG_PATH: tsconfigPath } : {}) },
+      });
+      status = ret.status ?? 1;
+    } finally {
+      if (tsconfigPath) {
+        fs.rmSync(tsconfigPath, { force: true });
+      }
+    }
+    process.exit(status);
   },
 };
+
+function createTsxTsconfig(cwd: string, file: string): string {
+  const realCwd = fs.realpathSync(cwd);
+  const configFile = findConfigFile(realCwd);
+  const configDirPath = path.dirname(fs.realpathSync(path.resolve(realCwd, file)));
+  const tempConfigFile = path.join(configDirPath, `.build-ts-tsx.${process.pid}.${Date.now()}.json`);
+  const config: Record<string, unknown> = {
+    compilerOptions: {
+      experimentalDecorators: true,
+    },
+    include: getTsxTsconfigIncludes(configDirPath, realCwd),
+  };
+  if (configFile) {
+    config.extends = toRelativeConfigPath(configDirPath, configFile);
+  }
+  fs.writeFileSync(tempConfigFile, JSON.stringify(config, undefined, 2));
+  return tempConfigFile;
+}
+
+function getTsxTsconfigIncludes(configDirPath: string, cwd: string): string[] {
+  const relativePath = path.relative(configDirPath, cwd).replaceAll(path.sep, '/');
+  if (!relativePath) return ['**/*'];
+
+  const relativeCwdPath = relativePath.startsWith('.') ? relativePath : `./${relativePath}`;
+  return ['**/*', `${relativeCwdPath}/**/*`];
+}
+
+function findConfigFile(dirPath: string): string | undefined {
+  let currentDirPath = path.resolve(dirPath);
+  while (true) {
+    const configFile = path.join(currentDirPath, 'tsconfig.json');
+    if (fs.existsSync(configFile)) return configFile;
+
+    const parentDirPath = path.dirname(currentDirPath);
+    if (parentDirPath === currentDirPath) return undefined;
+    currentDirPath = parentDirPath;
+  }
+}
+
+function toRelativeConfigPath(fromDirPath: string, toFilePath: string): string {
+  const relativePath = path.relative(fromDirPath, toFilePath).replaceAll(path.sep, '/');
+  return relativePath.startsWith('.') ? relativePath : `./${relativePath}`;
+}


### PR DESCRIPTION
Close #195

## Summary

- Create a temporary tsconfig for `build-ts run` when using `tsx` under Node.
- Enable `experimentalDecorators` so legacy TypeScript method decorators receive the expected `(target, key, descriptor)` arguments.
- Keep the temp config scoped to the invoked script and current working tree, then clean it up after the child process exits.

## Why

- `tsx` uses standard decorator semantics unless `experimentalDecorators` is enabled for the transformed file.
- Decorator helpers like `@retryIfPlaywrightTimeoutError` commonly rely on legacy TypeScript decorator arguments, which caused runtime failures.

## Testing

- `node bin/index.js run <tmp decorator script> --no-auto-cascade-env`
- `yarn check-for-ai`
