### PR TITLE
fix: resolve tsgo from the typescript package instead of @typescript/native-preview

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "rolldown": "1.1.4",
     "signal-exit": "4.1.0",
     "tsx": "4.23.0",
+    "typescript": "7.0.2",
     "yargs": "18.0.0"
   },
   "devDependencies": {
@@ -65,7 +66,6 @@
     "semantic-release": "25.0.5",
     "sort-package-json": "4.0.0",
     "type-fest": "5.8.0",
-    "typescript": "7.0.2",
     "vitest": "4.1.10"
   },
   "packageManager": "yarn@4.17.1",

--- a/src/commands/build/typeScript.ts
+++ b/src/commands/build/typeScript.ts
@@ -117,8 +117,10 @@ function findConfigFile(dirPath: string): string | undefined {
 }
 
 function getTsgoPath(): string {
-  const packageJsonPath = require.resolve('@typescript/native-preview/package.json');
-  return path.join(path.dirname(packageJsonPath), 'bin', 'tsgo.js');
+  // TypeScript 7 ships the native compiler (formerly `@typescript/native-preview`) as
+  // the `typescript` package, whose `lib/tsc.js` wrapper spawns the platform binary.
+  const packageJsonPath = require.resolve('typescript/package.json');
+  return path.join(path.dirname(packageJsonPath), 'lib', 'tsc.js');
 }
 
 async function usesNodeProtocolImport(dirPath: string): Promise<boolean> {


### PR DESCRIPTION
## Customer Summary

- Fixes `build-ts lib` (and any lib/functions declaration emit) crashing with `Cannot find module '@typescript/native-preview/package.json'` in projects updated to build-ts 17.1.32+.

## Technical Summary

- `getTsgoPath()` now resolves the native compiler from the `typescript` package (`lib/tsc.js`, TypeScript 7) instead of the deprecated `@typescript/native-preview` package.
- Moved `typescript` from `devDependencies` to `dependencies` because it is resolved at runtime during declaration emit. wbfy keeps managed dependencies already present in `dependencies` there, so this placement is stable across future wbfy runs.

## Why

- wbfy migrated all repos (including this one, in "chore: willboosterify this repo") from `@typescript/native-preview` to TypeScript 7's `typescript` package and deleted the former from `dependencies`. However, the declaration-emit code still resolved `@typescript/native-preview`, so published build-ts 17.1.32/17.1.33 fail at runtime in consumer repos (e.g. WillBooster/shared PR #927 CI `autofix.ci` / `yarn run build`).

## Testing

- `yarn verify` — passed.
- `yarn test` — 56/56 tests passed.
- Manual E2E: `yarn start lib ~/ghq/github.com/WillBooster/shared/packages/shared-lib` (previously failing) now emits bundles and `.d.ts` files successfully.
