### PR TITLE
feat: add --out-dir and --declaration-only options

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,22 +73,22 @@ npx build-ts run src/main.ts -- --foo bar
 
 ### Common build options (`app`, `functions`, and `lib`)
 
-| Option                           | Alias | Default  | Description                                                                                            |
-| -------------------------------- | ----- | -------- | ------------------------------------------------------------------------------------------------------ |
-| `--input`                        | `-i`  | (auto)   | Source files to build. The first file is the main entry. Defaults to `src/index.{ts,tsx,cts,mts}`.     |
-| `--out-dir`                      | `-o`  | `dist`   | Output directory, resolved from the current directory (e.g., `../../dist/shared`).                     |
-| `--module-type`                  | `-m`  | (varies) | Output module format: `esm`, `cjs`, `either` (follow `package.json`'s `type`), or `both` (`lib` only). |
-| `--minify` / `--no-minify`       |       | `true`   | Enable/disable minification.                                                                           |
-| `--sourcemap` / `--no-sourcemap` |       | `true`   | Enable/disable sourcemaps.                                                                             |
-| `--watch`                        | `-w`  | `false`  | Rebuild on file changes.                                                                               |
-| `--external`                     |       |          | Additional dependencies to keep external (not bundled).                                                |
-| `--core-js`                      |       | `false`  | Inject `core-js` polyfills via Babel.                                                                  |
-| `--core-js-proposals`            |       | `false`  | Inject `core-js` polyfills including proposals via Babel.                                              |
-| `--inline`                       |       |          | Names of environment variables to inline into the bundle.                                              |
-| `--auto-inline`                  |       | `false`  | Inline all environment variables defined in `.env` files.                                              |
-| `--keep-import`                  |       |          | Identifiers to keep as import statements.                                                              |
-| `--bundle-builtins`              |       |          | Module names that shadow Node.js builtins (e.g., `undici`) to be bundled.                              |
-| `--silent`                       | `-s`  | `false`  | Suppress non-error output.                                                                             |
+| Option                           | Alias | Default  | Description                                                                                                 |
+| -------------------------------- | ----- | -------- | ----------------------------------------------------------------------------------------------------------- |
+| `--input`                        | `-i`  | (auto)   | Source files to build. The first file is the main entry. Defaults to `src/index.{ts,tsx,cts,mts}`.          |
+| `--out-dir`                      | `-o`  | `dist`   | Output directory, resolved from the current directory (e.g., `../../dist/shared`). Removed before building. |
+| `--module-type`                  | `-m`  | (varies) | Output module format: `esm`, `cjs`, `either` (follow `package.json`'s `type`), or `both` (`lib` only).      |
+| `--minify` / `--no-minify`       |       | `true`   | Enable/disable minification.                                                                                |
+| `--sourcemap` / `--no-sourcemap` |       | `true`   | Enable/disable sourcemaps.                                                                                  |
+| `--watch`                        | `-w`  | `false`  | Rebuild on file changes.                                                                                    |
+| `--external`                     |       |          | Additional dependencies to keep external (not bundled).                                                     |
+| `--core-js`                      |       | `false`  | Inject `core-js` polyfills via Babel.                                                                       |
+| `--core-js-proposals`            |       | `false`  | Inject `core-js` polyfills including proposals via Babel.                                                   |
+| `--inline`                       |       |          | Names of environment variables to inline into the bundle.                                                   |
+| `--auto-inline`                  |       | `false`  | Inline all environment variables defined in `.env` files.                                                   |
+| `--keep-import`                  |       |          | Identifiers to keep as import statements.                                                                   |
+| `--bundle-builtins`              |       |          | Module names that shadow Node.js builtins (e.g., `undici`) to be bundled.                                   |
+| `--silent`                       | `-s`  | `false`  | Suppress non-error output.                                                                                  |
 
 ### `functions`-specific options
 
@@ -105,7 +105,7 @@ npx build-ts run src/main.ts -- --foo bar
 
 When `--input` is given explicitly, declaration files are generated only for the entry files and the files they (transitively) import, matching the bundled JavaScript. Without `--input`, declarations cover all files under `src/`.
 
-Declaration generation compiles with `rootDir: src`, so every file (transitively) imported by the entries must live under the package's `src/`; with `--declaration-only`, entries importing sibling-package sources fail with `TS6059`.
+Declaration generation compiles with `rootDir: src`, so when `--input` is explicit or `--declaration-only` is used, every file (transitively) imported by the entries must live under the package's `src/`; entries importing sibling-package sources fail with `TS6059`.
 
 Run `npx build-ts <command> --help` for the full list of options, including environment-variable handling shared with other WillBooster tools.
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ npx build-ts run src/main.ts -- --foo bar
 
 When `--input` is given explicitly, declaration files are generated only for the entry files and the files they (transitively) import, matching the bundled JavaScript. Without `--input`, declarations cover all files under `src/`.
 
-Declaration generation compiles with `rootDir: src`, so when `--input` is explicit or `--declaration-only` is used, every file (transitively) imported by the entries must live under the package's `src/`; entries importing sibling-package sources fail with `TS6059`.
+Declaration generation compiles with `rootDir: src`, so every file (transitively) imported by the entries must live under the package's `src/`; entries importing sibling-package sources fail with `TS6059`.
 
 Run `npx build-ts <command> --help` for the full list of options, including environment-variable handling shared with other WillBooster tools.
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ npx build-ts run src/main.ts -- --foo bar
 | `--js-extension`     | `-j`  | `either` | Which format uses the `.js` extension: `either`, `both`, or `none`. Other formats use `.cjs` / `.mjs`. Avoid `both` together with `--module-type both`, since the two formats would write the same `.js` files. |
 | `--declaration-only` |       | `false`  | Emit only declaration (`.d.ts`) files without bundling JavaScript.                                                                                                                                              |
 
-When `--input` is given explicitly, declaration files are generated only for the entry files and the files they (transitively) import, matching the bundled JavaScript. Without `--input`, declarations cover all files under `src/`.
+When `--input` is given explicitly, declaration files are generated only for the entry files and the files they (transitively) import, matching the bundled JavaScript. Without `--input`, declarations cover all files under `src/`. Ambient declaration files (`src/**/*.d.{ts,mts,cts}`) always participate in type checking, so files they import may also emit declarations.
 
 Declaration generation compiles with `rootDir: src`, so every file (transitively) imported by the entries must live under the package's `src/`; entries importing sibling-package sources fail with `TS6059`.
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ npx build-ts run src/main.ts -- --foo bar
 
 When `--input` is given explicitly, declaration files are generated only for the entry files and the files they (transitively) import, matching the bundled JavaScript. Without `--input`, declarations cover all files under `src/`.
 
+Declaration generation compiles with `rootDir: src`, so every file (transitively) imported by the entries must live under the package's `src/`; with `--declaration-only`, entries importing sibling-package sources fail with `TS6059`.
+
 Run `npx build-ts <command> --help` for the full list of options, including environment-variable handling shared with other WillBooster tools.
 
 ## Console Removal

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ npx build-ts run src/main.ts -- --foo bar
 | Option                           | Alias | Default  | Description                                                                                            |
 | -------------------------------- | ----- | -------- | ------------------------------------------------------------------------------------------------------ |
 | `--input`                        | `-i`  | (auto)   | Source files to build. The first file is the main entry. Defaults to `src/index.{ts,tsx,cts,mts}`.     |
+| `--out-dir`                      | `-o`  | `dist`   | Output directory, resolved from the current directory (e.g., `../../dist/shared`).                     |
 | `--module-type`                  | `-m`  | (varies) | Output module format: `esm`, `cjs`, `either` (follow `package.json`'s `type`), or `both` (`lib` only). |
 | `--minify` / `--no-minify`       |       | `true`   | Enable/disable minification.                                                                           |
 | `--sourcemap` / `--no-sourcemap` |       | `true`   | Enable/disable sourcemaps.                                                                             |
@@ -97,9 +98,12 @@ npx build-ts run src/main.ts -- --foo bar
 
 ### `lib`-specific options
 
-| Option           | Alias | Default  | Description                                                                                                                                                                                                     |
-| ---------------- | ----- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--js-extension` | `-j`  | `either` | Which format uses the `.js` extension: `either`, `both`, or `none`. Other formats use `.cjs` / `.mjs`. Avoid `both` together with `--module-type both`, since the two formats would write the same `.js` files. |
+| Option               | Alias | Default  | Description                                                                                                                                                                                                     |
+| -------------------- | ----- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--js-extension`     | `-j`  | `either` | Which format uses the `.js` extension: `either`, `both`, or `none`. Other formats use `.cjs` / `.mjs`. Avoid `both` together with `--module-type both`, since the two formats would write the same `.js` files. |
+| `--declaration-only` |       | `false`  | Emit only declaration (`.d.ts`) files without bundling JavaScript.                                                                                                                                              |
+
+When `--input` is given explicitly, declaration files are generated only for the entry files and the files they (transitively) import, matching the bundled JavaScript. Without `--input`, declarations cover all files under `src/`.
 
 Run `npx build-ts <command> --help` for the full list of options, including environment-variable handling shared with other WillBooster tools.
 

--- a/src/commands/build/build.ts
+++ b/src/commands/build/build.ts
@@ -41,7 +41,11 @@ export const functions: CommandModule<unknown, ArgumentsType<typeof functionsBui
         console.error(`Failed to parse package.json (${packageJsonPath}).`);
         process.exit(1);
       }
-      await generatePackageJsonForFunctions(resolveOutDirPath(argv, process.cwd(), packageDirPath), packageJson, argv.moduleType);
+      await generatePackageJsonForFunctions(
+        resolveOutDirPath(argv, process.cwd(), packageDirPath, undefined, 'functions'),
+        packageJson,
+        argv.moduleType
+      );
     } else {
       return build(argv, 'functions');
     }
@@ -75,7 +79,7 @@ export async function build(argv: ArgumentsType<AnyBuilderType>, targetCategory:
 
   const inputs = verifyInput(argv, cwd, packageDirPath);
   const targetDetail = detectTargetDetail(targetCategory, inputs, packageDirPath);
-  const outDirPath = resolveOutDirPath(argv, cwd, packageDirPath, inputs);
+  const outDirPath = resolveOutDirPath(argv, cwd, packageDirPath, inputs, targetCategory);
   // Restrict declaration files to the entry files (and their imports) only when inputs are explicit,
   // to keep the default behavior of emitting declarations for all files under src/.
   const declarationInputs = argv.input?.length ? inputs : undefined;
@@ -320,32 +324,62 @@ function resolveOutDirPath(
   argv: ArgumentsType<AnyBuilderType>,
   cwd: string,
   packageDirPath: string,
-  inputs?: string[]
+  inputs?: string[],
+  targetCategory?: TargetCategory
 ): string {
   if (!argv.outDir) return path.join(packageDirPath, 'dist');
 
   // The output directory is removed before building, so refuse locations that would delete source files.
-  const outDirPath = path.resolve(cwd, argv.outDir);
-  if (containsPath(outDirPath, packageDirPath)) {
-    console.error(`--out-dir (${outDirPath}) must not contain the package directory (${packageDirPath}).`);
+  // Comparisons use canonical (symlink-resolved) paths because `fs.rm` follows symlinks in parent components.
+  const outDirPath = toCanonicalPath(path.resolve(cwd, argv.outDir));
+  const canonicalPackageDirPath = toCanonicalPath(packageDirPath);
+  if (containsPath(outDirPath, canonicalPackageDirPath)) {
+    console.error(`--out-dir (${outDirPath}) must not contain the package directory (${canonicalPackageDirPath}).`);
     process.exit(1);
   }
-  const srcDirPath = path.join(packageDirPath, 'src');
+  const srcDirPath = path.join(canonicalPackageDirPath, 'src');
   if (containsPath(srcDirPath, outDirPath)) {
     console.error(`--out-dir (${outDirPath}) must not be inside the source directory (${srcDirPath}).`);
     process.exit(1);
   }
-  const containedInput = inputs?.find((input) => containsPath(outDirPath, input));
+  const containedInput = inputs?.find((input) => containsPath(outDirPath, toCanonicalPath(input)));
   if (containedInput) {
     console.error(`--out-dir (${outDirPath}) must not contain the input file (${containedInput}).`);
+    process.exit(1);
+  }
+  // A package.json at the output directory root indicates another package's directory. The functions
+  // target is exempt because it generates a package.json there itself.
+  if (targetCategory !== 'functions' && fs.existsSync(path.join(outDirPath, 'package.json'))) {
+    console.error(`--out-dir (${outDirPath}) contains a package.json, so it looks like a package directory.`);
     process.exit(1);
   }
   return outDirPath;
 }
 
+// Resolves symlinks in the longest existing ancestor of the given path, keeping the non-existent tail.
+function toCanonicalPath(targetPath: string): string {
+  const suffixes: string[] = [];
+  let currentPath = targetPath;
+  while (!fs.existsSync(currentPath)) {
+    suffixes.unshift(path.basename(currentPath));
+    const parentPath = path.dirname(currentPath);
+    if (parentPath === currentPath) break;
+    currentPath = parentPath;
+  }
+  try {
+    currentPath = fs.realpathSync(currentPath);
+  } catch {
+    // Keep the original path when it cannot be resolved (e.g. removed concurrently).
+  }
+  return path.join(currentPath, ...suffixes);
+}
+
 function containsPath(parentPath: string, childPath: string): boolean {
   const relativePath = path.relative(parentPath, childPath);
-  return relativePath === '' || (!relativePath.startsWith('..') && !path.isAbsolute(relativePath));
+  if (relativePath === '') return true;
+  if (path.isAbsolute(relativePath)) return false;
+  // Only an actual `..` segment means "outside"; a child name like `..foo` also starts with `..`.
+  return relativePath !== '..' && !relativePath.startsWith(`..${path.sep}`);
 }
 
 function getInputFiles(input: RolldownOptions['input']): string[] {

--- a/src/commands/build/build.ts
+++ b/src/commands/build/build.ts
@@ -337,7 +337,8 @@ function resolveOutDirPath(
     console.error(`--out-dir (${outDirPath}) must not contain the package directory (${canonicalPackageDirPath}).`);
     process.exit(1);
   }
-  const srcDirPath = path.join(canonicalPackageDirPath, 'src');
+  // `src` itself may be a symlink, so it needs its own canonicalization.
+  const srcDirPath = toCanonicalPath(path.join(canonicalPackageDirPath, 'src'));
   if (containsPath(srcDirPath, outDirPath)) {
     console.error(`--out-dir (${outDirPath}) must not be inside the source directory (${srcDirPath}).`);
     process.exit(1);

--- a/src/commands/build/build.ts
+++ b/src/commands/build/build.ts
@@ -327,7 +327,9 @@ function resolveOutDirPath(
   inputs?: string[],
   targetCategory?: TargetCategory
 ): string {
-  if (argv.outDir === '') {
+  // yargs also accepts `--no-out-dir`, which yields `false` despite the declared string type.
+  const outDirOption = typeof argv.outDir === 'string' ? argv.outDir : undefined;
+  if (outDirOption === '') {
     console.error('--out-dir must not be empty.');
     process.exit(1);
   }
@@ -336,14 +338,14 @@ function resolveOutDirPath(
   // Containment checks use canonical (symlink-resolved) paths because `fs.rm` follows symlinks in parent
   // components, but the lexical path is returned so that removing a symlinked output directory deletes
   // the symlink itself rather than its target's contents.
-  const lexicalOutDirPath = path.resolve(cwd, argv.outDir ?? path.join(packageDirPath, 'dist'));
+  const lexicalOutDirPath = path.resolve(cwd, outDirOption ?? path.join(packageDirPath, 'dist'));
   const outDirPath = toCanonicalPath(lexicalOutDirPath);
   const containedInput = inputs?.find((input) => containsPath(outDirPath, toCanonicalPath(input)));
   if (containedInput) {
     console.error(`The output directory (${outDirPath}) must not contain the input file (${containedInput}).`);
     process.exit(1);
   }
-  if (!argv.outDir) return lexicalOutDirPath;
+  if (!outDirOption) return lexicalOutDirPath;
 
   const canonicalPackageDirPath = toCanonicalPath(packageDirPath);
   if (containsPath(outDirPath, canonicalPackageDirPath)) {

--- a/src/commands/build/build.ts
+++ b/src/commands/build/build.ts
@@ -75,7 +75,7 @@ export async function build(argv: ArgumentsType<AnyBuilderType>, targetCategory:
 
   const inputs = verifyInput(argv, cwd, packageDirPath);
   const targetDetail = detectTargetDetail(targetCategory, inputs, packageDirPath);
-  const outDirPath = resolveOutDirPath(argv, cwd, packageDirPath);
+  const outDirPath = resolveOutDirPath(argv, cwd, packageDirPath, inputs);
   // Restrict declaration files to the entry files (and their imports) only when inputs are explicit,
   // to keep the default behavior of emitting declarations for all files under src/.
   const declarationInputs = argv.input?.length ? inputs : undefined;
@@ -281,17 +281,17 @@ function watchRolldown(
           break;
         }
         case 'BUNDLE_END': {
-          if (argv.silent) break;
-
-          console.info(
-            styleText(
-              'green',
-              `Created ${styleText('bold', pathToRelativePath(event.output).join(', '))} in ${styleText(
-                'bold',
-                formatDuration(event.duration)
-              )}`
-            )
-          );
+          if (!argv.silent) {
+            console.info(
+              styleText(
+                'green',
+                `Created ${styleText('bold', pathToRelativePath(event.output).join(', '))} in ${styleText(
+                  'bold',
+                  formatDuration(event.duration)
+                )}`
+              )
+            );
+          }
 
           if (targetDetail !== 'app-node' && targetDetail !== 'functions') {
             await generateDeclarationFiles(argv, packageDirPath, outDirPath, declarationInputs);
@@ -316,17 +316,36 @@ function watchRolldown(
   });
 }
 
-function resolveOutDirPath(argv: ArgumentsType<AnyBuilderType>, cwd: string, packageDirPath: string): string {
+function resolveOutDirPath(
+  argv: ArgumentsType<AnyBuilderType>,
+  cwd: string,
+  packageDirPath: string,
+  inputs?: string[]
+): string {
   if (!argv.outDir) return path.join(packageDirPath, 'dist');
 
+  // The output directory is removed before building, so refuse locations that would delete source files.
   const outDirPath = path.resolve(cwd, argv.outDir);
-  // The output directory is removed before building, so refuse a directory containing the package.
-  const relativePath = path.relative(outDirPath, packageDirPath);
-  if (relativePath === '' || (!relativePath.startsWith('..') && !path.isAbsolute(relativePath))) {
+  if (containsPath(outDirPath, packageDirPath)) {
     console.error(`--out-dir (${outDirPath}) must not contain the package directory (${packageDirPath}).`);
     process.exit(1);
   }
+  const srcDirPath = path.join(packageDirPath, 'src');
+  if (containsPath(srcDirPath, outDirPath)) {
+    console.error(`--out-dir (${outDirPath}) must not be inside the source directory (${srcDirPath}).`);
+    process.exit(1);
+  }
+  const containedInput = inputs?.find((input) => containsPath(outDirPath, input));
+  if (containedInput) {
+    console.error(`--out-dir (${outDirPath}) must not contain the input file (${containedInput}).`);
+    process.exit(1);
+  }
   return outDirPath;
+}
+
+function containsPath(parentPath: string, childPath: string): boolean {
+  const relativePath = path.relative(parentPath, childPath);
+  return relativePath === '' || (!relativePath.startsWith('..') && !path.isAbsolute(relativePath));
 }
 
 function getInputFiles(input: RolldownOptions['input']): string[] {

--- a/src/commands/build/build.ts
+++ b/src/commands/build/build.ts
@@ -327,15 +327,23 @@ function resolveOutDirPath(
   inputs?: string[],
   targetCategory?: TargetCategory
 ): string {
+  if (argv.outDir === '') {
+    console.error('--out-dir must not be empty.');
+    process.exit(1);
+  }
+
   // The output directory is removed before building, so refuse locations that would delete source files.
-  // Comparisons use canonical (symlink-resolved) paths because `fs.rm` follows symlinks in parent components.
-  const outDirPath = toCanonicalPath(path.resolve(cwd, argv.outDir ?? path.join(packageDirPath, 'dist')));
+  // Containment checks use canonical (symlink-resolved) paths because `fs.rm` follows symlinks in parent
+  // components, but the lexical path is returned so that removing a symlinked output directory deletes
+  // the symlink itself rather than its target's contents.
+  const lexicalOutDirPath = path.resolve(cwd, argv.outDir ?? path.join(packageDirPath, 'dist'));
+  const outDirPath = toCanonicalPath(lexicalOutDirPath);
   const containedInput = inputs?.find((input) => containsPath(outDirPath, toCanonicalPath(input)));
   if (containedInput) {
     console.error(`The output directory (${outDirPath}) must not contain the input file (${containedInput}).`);
     process.exit(1);
   }
-  if (!argv.outDir) return outDirPath;
+  if (!argv.outDir) return lexicalOutDirPath;
 
   const canonicalPackageDirPath = toCanonicalPath(packageDirPath);
   if (containsPath(outDirPath, canonicalPackageDirPath)) {
@@ -354,7 +362,7 @@ function resolveOutDirPath(
     console.error(`--out-dir (${outDirPath}) contains a package.json, so it looks like a package directory.`);
     process.exit(1);
   }
-  return outDirPath;
+  return lexicalOutDirPath;
 }
 
 // Resolves symlinks in the longest existing ancestor of the given path, keeping the non-existent tail.

--- a/src/commands/build/build.ts
+++ b/src/commands/build/build.ts
@@ -327,6 +327,10 @@ function resolveOutDirPath(
   inputs?: string[],
   targetCategory?: TargetCategory
 ): string {
+  if (Array.isArray(argv.outDir)) {
+    console.error('Multiple --out-dir options are not allowed.');
+    process.exit(1);
+  }
   // yargs also accepts `--no-out-dir`, which yields `false` despite the declared string type.
   const outDirOption = typeof argv.outDir === 'string' ? argv.outDir : undefined;
   if (outDirOption === '') {
@@ -335,12 +339,15 @@ function resolveOutDirPath(
   }
 
   // The output directory is removed before building, so refuse locations that would delete source files.
-  // Containment checks use canonical (symlink-resolved) paths because `fs.rm` follows symlinks in parent
-  // components, but the lexical path is returned so that removing a symlinked output directory deletes
-  // the symlink itself rather than its target's contents.
+  // Containment checks compare both the lexical and the canonical (symlink-resolved) forms: canonical
+  // ones catch symlinked parent components (`fs.rm` follows them), and lexical ones catch an output path
+  // that is itself a symlink inside a protected directory. The lexical path is returned so that removing
+  // a symlinked output directory deletes the symlink itself rather than its target's contents.
   const lexicalOutDirPath = path.resolve(cwd, outDirOption ?? path.join(packageDirPath, 'dist'));
   const outDirPath = toCanonicalPath(lexicalOutDirPath);
-  const containedInput = inputs?.find((input) => containsPath(outDirPath, toCanonicalPath(input)));
+  const containedInput = inputs?.find(
+    (input) => containsPath(outDirPath, toCanonicalPath(input)) || containsPath(lexicalOutDirPath, input)
+  );
   if (containedInput) {
     console.error(`The output directory (${outDirPath}) must not contain the input file (${containedInput}).`);
     process.exit(1);
@@ -348,13 +355,13 @@ function resolveOutDirPath(
   if (!outDirOption) return lexicalOutDirPath;
 
   const canonicalPackageDirPath = toCanonicalPath(packageDirPath);
-  if (containsPath(outDirPath, canonicalPackageDirPath)) {
+  if (containsPath(outDirPath, canonicalPackageDirPath) || containsPath(lexicalOutDirPath, packageDirPath)) {
     console.error(`--out-dir (${outDirPath}) must not contain the package directory (${canonicalPackageDirPath}).`);
     process.exit(1);
   }
   // `src` itself may be a symlink, so it needs its own canonicalization.
   const srcDirPath = toCanonicalPath(path.join(canonicalPackageDirPath, 'src'));
-  if (containsPath(srcDirPath, outDirPath)) {
+  if (containsPath(srcDirPath, outDirPath) || containsPath(path.join(packageDirPath, 'src'), lexicalOutDirPath)) {
     console.error(`--out-dir (${outDirPath}) must not be inside the source directory (${srcDirPath}).`);
     process.exit(1);
   }

--- a/src/commands/build/build.ts
+++ b/src/commands/build/build.ts
@@ -41,7 +41,7 @@ export const functions: CommandModule<unknown, ArgumentsType<typeof functionsBui
         console.error(`Failed to parse package.json (${packageJsonPath}).`);
         process.exit(1);
       }
-      await generatePackageJsonForFunctions(packageDirPath, packageJson, argv.moduleType);
+      await generatePackageJsonForFunctions(resolveOutDirPath(argv, process.cwd(), packageDirPath), packageJson, argv.moduleType);
     } else {
       return build(argv, 'functions');
     }
@@ -75,6 +75,10 @@ export async function build(argv: ArgumentsType<AnyBuilderType>, targetCategory:
 
   const inputs = verifyInput(argv, cwd, packageDirPath);
   const targetDetail = detectTargetDetail(targetCategory, inputs, packageDirPath);
+  const outDirPath = resolveOutDirPath(argv, cwd, packageDirPath);
+  // Restrict declaration files to the entry files (and their imports) only when inputs are explicit,
+  // to keep the default behavior of emitting declarations for all files under src/.
+  const declarationInputs = argv.input?.length ? inputs : undefined;
 
   if (verbose) {
     console.info('argv:', argv);
@@ -97,7 +101,13 @@ export async function build(argv: ArgumentsType<AnyBuilderType>, targetCategory:
   process.env.BUILD_TS_TARGET_CATEGORY = targetCategory;
   process.env.BUILD_TS_TARGET_DETAIL = targetDetail;
 
-  const outputOptionsList = getOutputOptionsList(argv, targetDetail, packageDirPath, isEsmPackage);
+  const declarationOnly = 'declarationOnly' in argv && argv.declarationOnly;
+  if (declarationOnly && argv.watch) {
+    console.error('--declaration-only cannot be used with --watch.');
+    process.exit(1);
+  }
+
+  const outputOptionsList = getOutputOptionsList(argv, targetDetail, outDirPath, isEsmPackage, packageDirPath);
   if (verbose) {
     console.info('OutputOptions:', outputOptionsList);
   }
@@ -107,9 +117,24 @@ export async function build(argv: ArgumentsType<AnyBuilderType>, targetCategory:
   }
 
   process.chdir(packageDirPath);
-  await fs.promises.rm(path.join(packageDirPath, 'dist'), { recursive: true, force: true });
+  await fs.promises.rm(outDirPath, { recursive: true, force: true });
   if (targetDetail === 'functions') {
-    await generatePackageJsonForFunctions(packageDirPath, packageJson, argv.moduleType);
+    await generatePackageJsonForFunctions(outDirPath, packageJson, argv.moduleType);
+  }
+
+  if (declarationOnly) {
+    if (!argv.silent) {
+      console.info(
+        styleText(
+          'cyan',
+          `Generates declaration files → ${styleText('bold', path.relative(packageDirPath, outDirPath))}\non ${packageDirPath} ...`
+        )
+      );
+    }
+    if (!(await generateDeclarationFiles(argv, packageDirPath, outDirPath, declarationInputs))) {
+      process.exit(1);
+    }
+    return;
   }
 
   const options: RolldownOptions = {
@@ -150,7 +175,17 @@ export async function build(argv: ArgumentsType<AnyBuilderType>, targetCategory:
     );
   };
   if (argv.watch) {
-    watchRolldown(argv, targetDetail, packageDirPath, options, outputOptionsList, pathToRelativePath, printBundlingMessage);
+    watchRolldown(
+      argv,
+      targetDetail,
+      packageDirPath,
+      outDirPath,
+      declarationInputs,
+      options,
+      outputOptionsList,
+      pathToRelativePath,
+      printBundlingMessage
+    );
   } else {
     if (!argv.silent) {
       printBundlingMessage(inputs);
@@ -184,7 +219,7 @@ export async function build(argv: ArgumentsType<AnyBuilderType>, targetCategory:
     if (
       targetDetail !== 'app-node' &&
       targetDetail !== 'functions' &&
-      !(await generateDeclarationFiles(argv, packageDirPath))
+      !(await generateDeclarationFiles(argv, packageDirPath, outDirPath, declarationInputs))
     ) {
       process.exit(1);
     }
@@ -203,6 +238,8 @@ function watchRolldown(
   argv: ArgumentsType<AnyBuilderType>,
   targetDetail: string,
   packageDirPath: string,
+  outDirPath: string,
+  declarationInputs: string[] | undefined,
   options: RolldownOptions,
   outputOptionsList: OutputOptions[],
   pathToRelativePath: (paths: string | Readonly<string[]>) => string[],
@@ -257,7 +294,7 @@ function watchRolldown(
           );
 
           if (targetDetail !== 'app-node' && targetDetail !== 'functions') {
-            await generateDeclarationFiles(argv, packageDirPath);
+            await generateDeclarationFiles(argv, packageDirPath, outDirPath, declarationInputs);
           }
           break;
         }
@@ -277,6 +314,19 @@ function watchRolldown(
       }
     }
   });
+}
+
+function resolveOutDirPath(argv: ArgumentsType<AnyBuilderType>, cwd: string, packageDirPath: string): string {
+  if (!argv.outDir) return path.join(packageDirPath, 'dist');
+
+  const outDirPath = path.resolve(cwd, argv.outDir);
+  // The output directory is removed before building, so refuse a directory containing the package.
+  const relativePath = path.relative(outDirPath, packageDirPath);
+  if (relativePath === '' || (!relativePath.startsWith('..') && !path.isAbsolute(relativePath))) {
+    console.error(`--out-dir (${outDirPath}) must not contain the package directory (${packageDirPath}).`);
+    process.exit(1);
+  }
+  return outDirPath;
 }
 
 function getInputFiles(input: RolldownOptions['input']): string[] {
@@ -338,7 +388,7 @@ function doesDirectoryContainTsx(dirPath: string): boolean {
 }
 
 async function generatePackageJsonForFunctions(
-  packageDirPath: string,
+  outDirPath: string,
   packageJson: PackageJson,
   moduleType: string | undefined
 ): Promise<void> {
@@ -352,17 +402,17 @@ async function generatePackageJsonForFunctions(
   // devDependencies are not required since we are building code before deploying.
   delete packageJson.devDependencies;
 
-  await fs.promises.mkdir(path.join(packageDirPath, 'dist'), { recursive: true });
-  await fs.promises.writeFile(path.join(packageDirPath, 'dist', 'package.json'), JSON.stringify(packageJson));
+  await fs.promises.mkdir(outDirPath, { recursive: true });
+  await fs.promises.writeFile(path.join(outDirPath, 'package.json'), JSON.stringify(packageJson));
 }
 
 function getOutputOptionsList(
   argv: ArgumentsType<AnyBuilderType>,
   targetDetail: TargetDetail,
-  packageDirPath: string,
-  isEsmPackage: boolean
+  outDirPath: string,
+  isEsmPackage: boolean,
+  packageDirPath: string
 ): OutputOptions[] {
-  const outDirPath = path.join(packageDirPath, 'dist');
   if (targetDetail === 'app-node' || targetDetail === 'functions') {
     const esmOutput = isEsmOutput(isEsmPackage, argv.moduleType);
     return [

--- a/src/commands/build/build.ts
+++ b/src/commands/build/build.ts
@@ -327,11 +327,16 @@ function resolveOutDirPath(
   inputs?: string[],
   targetCategory?: TargetCategory
 ): string {
-  if (!argv.outDir) return path.join(packageDirPath, 'dist');
-
   // The output directory is removed before building, so refuse locations that would delete source files.
   // Comparisons use canonical (symlink-resolved) paths because `fs.rm` follows symlinks in parent components.
-  const outDirPath = toCanonicalPath(path.resolve(cwd, argv.outDir));
+  const outDirPath = toCanonicalPath(path.resolve(cwd, argv.outDir ?? path.join(packageDirPath, 'dist')));
+  const containedInput = inputs?.find((input) => containsPath(outDirPath, toCanonicalPath(input)));
+  if (containedInput) {
+    console.error(`The output directory (${outDirPath}) must not contain the input file (${containedInput}).`);
+    process.exit(1);
+  }
+  if (!argv.outDir) return outDirPath;
+
   const canonicalPackageDirPath = toCanonicalPath(packageDirPath);
   if (containsPath(outDirPath, canonicalPackageDirPath)) {
     console.error(`--out-dir (${outDirPath}) must not contain the package directory (${canonicalPackageDirPath}).`);
@@ -341,11 +346,6 @@ function resolveOutDirPath(
   const srcDirPath = toCanonicalPath(path.join(canonicalPackageDirPath, 'src'));
   if (containsPath(srcDirPath, outDirPath)) {
     console.error(`--out-dir (${outDirPath}) must not be inside the source directory (${srcDirPath}).`);
-    process.exit(1);
-  }
-  const containedInput = inputs?.find((input) => containsPath(outDirPath, toCanonicalPath(input)));
-  if (containedInput) {
-    console.error(`--out-dir (${outDirPath}) must not contain the input file (${containedInput}).`);
     process.exit(1);
   }
   // A package.json at the output directory root indicates another package's directory. The functions

--- a/src/commands/build/builder.ts
+++ b/src/commands/build/builder.ts
@@ -32,6 +32,11 @@ export const builder = {
     description: 'Additional external dependencies.',
     type: 'array',
   },
+  outDir: {
+    description: 'Output directory. Defaults to "dist" in the package directory.',
+    type: 'string',
+    alias: 'o',
+  },
   inline: {
     description: 'Environment variables to be inlined.',
     type: 'array',
@@ -87,6 +92,11 @@ export const libBuilder = {
     description: 'Whether to use .js in cjs and/or esm: either (default), both, or none.',
     type: 'string',
     alias: 'j',
+  },
+  declarationOnly: {
+    description: 'Emit only declaration (.d.ts) files without bundling JavaScript.',
+    type: 'boolean',
+    default: false,
   },
 } as const;
 

--- a/src/commands/build/typeScript.ts
+++ b/src/commands/build/typeScript.ts
@@ -122,6 +122,7 @@ async function createTypeScriptNativeConfig(
     // declaration files are kept because entries may rely on their global types without importing them.
     ...(inputs?.length
       ? {
+          exclude: [],
           files: inputs.map((input) => path.resolve(projectDirPath, input).replaceAll(path.sep, '/')),
           include: ['src/**/*.d.ts', 'src/**/*.d.mts', 'src/**/*.d.cts'],
         }

--- a/src/commands/build/typeScript.ts
+++ b/src/commands/build/typeScript.ts
@@ -91,10 +91,14 @@ async function createTypeScriptNativeConfig(
   inputs?: string[]
 ): Promise<Record<string, unknown>> {
   const compilerOptions: Record<string, unknown> = {
+    // An inherited `composite` would require listing every imported file explicitly (TS6307) and,
+    // like `incremental`, would write needless .tsbuildinfo files for this one-shot compilation.
+    composite: false,
     declaration: true,
     // An inherited `declarationDir` would silently redirect the output away from `outDir`.
     declarationDir: outDir,
     emitDeclarationOnly: true,
+    incremental: false,
     noEmit: false,
     noEmitOnError: true,
     outDir,

--- a/src/commands/build/typeScript.ts
+++ b/src/commands/build/typeScript.ts
@@ -91,10 +91,14 @@ async function createTypeScriptNativeConfig(
 ): Promise<Record<string, unknown>> {
   const compilerOptions: Record<string, unknown> = {
     declaration: true,
+    // An inherited `declarationDir` would silently redirect the output away from `outDir`.
+    declarationDir: outDir,
     emitDeclarationOnly: true,
     noEmit: false,
     noEmitOnError: true,
     outDir,
+    // TypeScript 7 requires an explicit `rootDir` (TS5011). Entries importing files outside src/
+    // (e.g. sibling packages in declaration-only mode) fail with TS6059; see the README limitation.
     rootDir: 'src',
   };
   if (await usesNodeProtocolImport(path.join(projectDirPath, 'src'))) {
@@ -109,8 +113,9 @@ async function createTypeScriptNativeConfig(
     extends: toRelativeConfigPath(path.dirname(configFile), configFile),
     // With `files`, tsc also emits declarations for files transitively imported from the entries,
     // so the output is restricted to what the bundled JavaScript actually contains.
+    // `include` must be emptied since an inherited `include` would add files back to the program.
     ...(inputs?.length
-      ? { files: inputs.map((input) => path.resolve(projectDirPath, input).replaceAll(path.sep, '/')) }
+      ? { files: inputs.map((input) => path.resolve(projectDirPath, input).replaceAll(path.sep, '/')), include: [] }
       : { include: ['src/**/*'] }),
   };
 }
@@ -172,6 +177,8 @@ async function collectTypePackages(typeRootsDirPath: string): Promise<string[]> 
   }
 }
 
+// `fromDirPath` is always the directory containing `toFilePath`, so the result is a bare file name
+// prefixed with `./`; a cross-drive absolute result is impossible.
 function toRelativeConfigPath(fromDirPath: string, toFilePath: string): string {
   const relativePath = path.relative(fromDirPath, toFilePath).replaceAll(path.sep, '/');
   return relativePath.startsWith('.') ? relativePath : `./${relativePath}`;

--- a/src/commands/build/typeScript.ts
+++ b/src/commands/build/typeScript.ts
@@ -112,10 +112,14 @@ async function createTypeScriptNativeConfig(
     compilerOptions,
     extends: toRelativeConfigPath(path.dirname(configFile), configFile),
     // With `files`, tsc also emits declarations for files transitively imported from the entries,
-    // so the output is restricted to what the bundled JavaScript actually contains.
-    // `include` must be emptied since an inherited `include` would add files back to the program.
+    // so the output is restricted to what the bundled JavaScript actually contains. `include` must be
+    // overridden since an inherited `include` would add files back to the program; only ambient
+    // declaration files are kept because entries may rely on their global types without importing them.
     ...(inputs?.length
-      ? { files: inputs.map((input) => path.resolve(projectDirPath, input).replaceAll(path.sep, '/')), include: [] }
+      ? {
+          files: inputs.map((input) => path.resolve(projectDirPath, input).replaceAll(path.sep, '/')),
+          include: ['src/**/*.d.ts'],
+        }
       : { include: ['src/**/*'] }),
   };
 }

--- a/src/commands/build/typeScript.ts
+++ b/src/commands/build/typeScript.ts
@@ -11,7 +11,9 @@ const require = createRequire(import.meta.url);
 
 export async function generateDeclarationFiles(
   argv: ArgumentsType<AnyBuilderType>,
-  coreProjectDirPath: string
+  coreProjectDirPath: string,
+  outDirPath: string,
+  inputs?: string[]
 ): Promise<boolean> {
   const coreConfigFile = findConfigFile(coreProjectDirPath);
   if (!coreConfigFile) throw new Error(`Failed to find tsconfig.json in ${coreProjectDirPath}.`);
@@ -19,9 +21,12 @@ export async function generateDeclarationFiles(
     console.info('Found tsconfig.json:', coreConfigFile);
   }
 
-  const projects: [string, string, string][] = [];
-  let outDir = path.join('dist', path.basename(coreProjectDirPath), 'src');
-  if (fs.existsSync(outDir)) {
+  const projects: [string, string, string, string[] | undefined][] = [];
+  let coreOutDir = path.join(outDirPath, path.basename(coreProjectDirPath), 'src');
+  if (fs.existsSync(coreOutDir)) {
+    // The bundler emitted per-project directories (monorepo build), so entry-based restriction is unsafe:
+    // entries may import files outside each project's rootDir.
+    inputs = undefined;
     const parentDirPath = path.dirname(coreProjectDirPath);
     const dirents = await fs.promises.readdir(parentDirPath, { withFileTypes: true });
     coreProjectDirPath = path.resolve(coreProjectDirPath);
@@ -32,19 +37,19 @@ export async function generateDeclarationFiles(
       if (projectDirPath === coreProjectDirPath) continue;
 
       const configFile = findConfigFile(projectDirPath);
-      const outDir = path.join('dist', dirent.name, 'src');
+      const outDir = path.join(outDirPath, dirent.name, 'src');
       if (configFile && fs.existsSync(outDir)) {
-        projects.push([projectDirPath, configFile, outDir]);
+        projects.push([projectDirPath, configFile, outDir, undefined]);
       }
     }
   } else {
-    outDir = 'dist';
+    coreOutDir = outDirPath;
   }
-  projects.push([coreProjectDirPath, coreConfigFile, outDir]);
+  projects.push([coreProjectDirPath, coreConfigFile, coreOutDir, inputs]);
 
   let allSucceeded = true;
-  for (const [projectDirPath, configFile, outDir] of projects) {
-    allSucceeded &&= await runTsgo(argv, projectDirPath, configFile, path.join(coreProjectDirPath, outDir));
+  for (const [projectDirPath, configFile, outDir, projectInputs] of projects) {
+    allSucceeded &&= await runTsgo(argv, projectDirPath, configFile, outDir, projectInputs);
   }
   return allSucceeded;
 }
@@ -53,10 +58,11 @@ async function runTsgo(
   argv: ArgumentsType<AnyBuilderType>,
   projectDirPath: string,
   configFile: string,
-  outDir: string
+  outDir: string,
+  inputs?: string[]
 ): Promise<boolean> {
   if (argv.verbose) {
-    console.info('runTsgo()', projectDirPath, configFile, outDir);
+    console.info('runTsgo()', projectDirPath, configFile, outDir, inputs);
   }
 
   const configFileDirPath = path.dirname(configFile);
@@ -64,7 +70,7 @@ async function runTsgo(
   try {
     await fs.promises.writeFile(
       tempConfigFile,
-      JSON.stringify(await createTypeScriptNativeConfig(projectDirPath, configFile, outDir), undefined, 2)
+      JSON.stringify(await createTypeScriptNativeConfig(projectDirPath, configFile, outDir, inputs), undefined, 2)
     );
     const ret = child_process.spawnSync(process.execPath, [getTsgoPath(), '-p', tempConfigFile], {
       cwd: projectDirPath,
@@ -80,7 +86,8 @@ async function runTsgo(
 async function createTypeScriptNativeConfig(
   projectDirPath: string,
   configFile: string,
-  outDir: string
+  outDir: string,
+  inputs?: string[]
 ): Promise<Record<string, unknown>> {
   const compilerOptions: Record<string, unknown> = {
     declaration: true,
@@ -100,7 +107,11 @@ async function createTypeScriptNativeConfig(
   return {
     compilerOptions,
     extends: toRelativeConfigPath(path.dirname(configFile), configFile),
-    include: ['src/**/*'],
+    // With `files`, tsc also emits declarations for files transitively imported from the entries,
+    // so the output is restricted to what the bundled JavaScript actually contains.
+    ...(inputs?.length
+      ? { files: inputs.map((input) => path.resolve(projectDirPath, input).replaceAll(path.sep, '/')) }
+      : { include: ['src/**/*'] }),
   };
 }
 

--- a/src/commands/build/typeScript.ts
+++ b/src/commands/build/typeScript.ts
@@ -65,8 +65,9 @@ async function runTsgo(
     console.info('runTsgo()', projectDirPath, configFile, outDir, inputs);
   }
 
-  const configFileDirPath = path.dirname(configFile);
-  const tempConfigFile = path.join(configFileDirPath, `.build-ts-tsgo.${process.pid}.${Date.now()}.json`);
+  // The temporary config must live in the project directory so that its relative `rootDir` and
+  // `include` resolve against the project even when the extended tsconfig is in an ancestor directory.
+  const tempConfigFile = path.join(projectDirPath, `.build-ts-tsgo.${process.pid}.${Date.now()}.json`);
   try {
     await fs.promises.writeFile(
       tempConfigFile,
@@ -110,7 +111,7 @@ async function createTypeScriptNativeConfig(
   }
   return {
     compilerOptions,
-    extends: toRelativeConfigPath(path.dirname(configFile), configFile),
+    extends: toRelativeConfigPath(projectDirPath, configFile),
     // With `files`, tsc also emits declarations for files transitively imported from the entries,
     // so the output is restricted to what the bundled JavaScript actually contains. `include` must be
     // overridden since an inherited `include` would add files back to the program; only ambient
@@ -118,7 +119,7 @@ async function createTypeScriptNativeConfig(
     ...(inputs?.length
       ? {
           files: inputs.map((input) => path.resolve(projectDirPath, input).replaceAll(path.sep, '/')),
-          include: ['src/**/*.d.ts'],
+          include: ['src/**/*.d.ts', 'src/**/*.d.mts', 'src/**/*.d.cts'],
         }
       : { include: ['src/**/*'] }),
   };
@@ -181,8 +182,8 @@ async function collectTypePackages(typeRootsDirPath: string): Promise<string[]> 
   }
 }
 
-// `fromDirPath` is always the directory containing `toFilePath`, so the result is a bare file name
-// prefixed with `./`; a cross-drive absolute result is impossible.
+// `toFilePath` is always a tsconfig in `fromDirPath` or one of its ancestor directories, so the
+// result is always relative (`./` or `../` chains); a cross-drive absolute result is impossible.
 function toRelativeConfigPath(fromDirPath: string, toFilePath: string): string {
   const relativePath = path.relative(fromDirPath, toFilePath).replaceAll(path.sep, '/');
   return relativePath.startsWith('.') ? relativePath : `./${relativePath}`;

--- a/test/build.test.ts
+++ b/test/build.test.ts
@@ -1526,6 +1526,12 @@ process.stdout.write(marker);
     );
     await fs.promises.writeFile(`${fixtureDirPath}/yarn.lock`, '');
     await fs.promises.writeFile(
+      `${fixtureDirPath}/tsconfig.json`,
+      JSON.stringify({
+        compilerOptions: { module: 'esnext', moduleResolution: 'bundler', strict: true, target: 'es2022' },
+      })
+    );
+    await fs.promises.writeFile(
       `${fixtureDirPath}/src/index.ts`,
       `export function run() {
   return [1, 2, 3].includes(2) && [1].flatMap((value) => [value]).at(-1) === 1;

--- a/test/build.test.ts
+++ b/test/build.test.ts
@@ -1548,6 +1548,74 @@ process.stdout.write(marker);
     expect(esmRet.status).toBe(0);
   });
 
+  it('lib with --out-dir and --declaration-only', async () => {
+    const fixtureDirPath = '.tmp/test-fixtures/lib-custom-out';
+    await fs.promises.rm(fixtureDirPath, { recursive: true, force: true });
+    await fs.promises.mkdir(`${fixtureDirPath}/src`, { recursive: true });
+    await fs.promises.writeFile(
+      `${fixtureDirPath}/package.json`,
+      JSON.stringify({
+        type: 'module',
+        packageManager: 'yarn@4.17.0',
+      })
+    );
+    await fs.promises.writeFile(`${fixtureDirPath}/yarn.lock`, '');
+    await fs.promises.writeFile(
+      `${fixtureDirPath}/tsconfig.json`,
+      JSON.stringify({
+        compilerOptions: { module: 'esnext', moduleResolution: 'bundler', strict: true, target: 'es2022' },
+      })
+    );
+    await fs.promises.writeFile(
+      `${fixtureDirPath}/src/routes.ts`,
+      `import { helper } from './helper.js';
+export const routes = { helper };
+`
+    );
+    await fs.promises.writeFile(
+      `${fixtureDirPath}/src/helper.ts`,
+      'export function helper(): number {\n  return 1;\n}\n'
+    );
+    await fs.promises.writeFile(`${fixtureDirPath}/src/unreachable.ts`, 'export const secret = 42;\n');
+
+    const runtimeOutDirPath = '.tmp/test-fixtures/lib-custom-out-runtime';
+    await fs.promises.rm(runtimeOutDirPath, { recursive: true, force: true });
+    await buildWithPackagePath(
+      fixtureDirPath,
+      'lib',
+      '--module-type',
+      'esm',
+      '--input',
+      `${fixtureDirPath}/src/routes.ts`,
+      '--out-dir',
+      runtimeOutDirPath
+    );
+    const runtimeFileNames = await fs.promises.readdir(runtimeOutDirPath);
+    expect(runtimeFileNames.toSorted()).toEqual([
+      'helper.d.ts',
+      'helper.js',
+      'helper.js.map',
+      'routes.d.ts',
+      'routes.js',
+      'routes.js.map',
+    ]);
+    expect(fs.existsSync(`${fixtureDirPath}/dist`)).toBe(false);
+
+    const typesOutDirPath = '.tmp/test-fixtures/lib-custom-out-types';
+    await fs.promises.rm(typesOutDirPath, { recursive: true, force: true });
+    await buildWithPackagePath(
+      fixtureDirPath,
+      'lib',
+      '--declaration-only',
+      '--input',
+      `${fixtureDirPath}/src/routes.ts`,
+      '--out-dir',
+      typesOutDirPath
+    );
+    const typesFileNames = await fs.promises.readdir(typesOutDirPath);
+    expect(typesFileNames.toSorted()).toEqual(['helper.d.ts', 'routes.d.ts']);
+  });
+
   it('lib-react-ts-entry', async () => {
     const dirName = 'lib-react-ts-entry';
     await buildWithCommand(dirName, 'lib', '--module-type', 'both');

--- a/test/build.test.ts
+++ b/test/build.test.ts
@@ -1563,7 +1563,16 @@ process.stdout.write(marker);
     await fs.promises.writeFile(
       `${fixtureDirPath}/tsconfig.json`,
       JSON.stringify({
-        compilerOptions: { module: 'esnext', moduleResolution: 'bundler', strict: true, target: 'es2022' },
+        // `declarationDir` and `include` must be overridden by build-ts; otherwise declarations
+        // would go to `configured-types` and cover `unreachable.ts` despite the explicit `--input`.
+        compilerOptions: {
+          declarationDir: 'configured-types',
+          module: 'esnext',
+          moduleResolution: 'bundler',
+          strict: true,
+          target: 'es2022',
+        },
+        include: ['src/**/*'],
       })
     );
     await fs.promises.writeFile(
@@ -1614,6 +1623,18 @@ export const routes = { helper };
     );
     const typesFileNames = await fs.promises.readdir(typesOutDirPath);
     expect(typesFileNames.toSorted()).toEqual(['helper.d.ts', 'routes.d.ts']);
+    expect(fs.existsSync(`${fixtureDirPath}/configured-types`)).toBe(false);
+
+    const failedRet = await buildWithPackagePathAndGetStatus(
+      fixtureDirPath,
+      'lib',
+      '--input',
+      `${fixtureDirPath}/src/routes.ts`,
+      '--out-dir',
+      `${fixtureDirPath}/src`
+    );
+    expect(failedRet.status).not.toBe(0);
+    expect(fs.existsSync(`${fixtureDirPath}/src/routes.ts`)).toBe(true);
   });
 
   it('lib-react-ts-entry', async () => {


### PR DESCRIPTION
## Customer Summary

- Packages can now build into a custom output directory (e.g., a repo-root `dist/`) and publish type-declaration-only artifacts for selected entry points, without hand-written `tsc` configs, `mv` steps, or declaration-pruning scripts.
- The output directory is removed before each build; new safety guards refuse output locations that would delete source files (the package directory, `src/`, input files, or another package's directory), including through symlinks.

## Technical Summary

- `--out-dir` (`-o`, common to `app` / `functions` / `lib`): changes the output directory (default remains `dist` in the package directory). Guards compare both lexical and symlink-resolved paths, reject empty/repeated values, and treat yargs's `--no-out-dir` as the default.
- `--declaration-only` (`lib`): emits only `.d.ts` files without bundling JavaScript (incompatible with `--watch`).
- With explicit `--input`, declaration generation restricts the program via tsconfig `files` to the entries and their transitive imports, while keeping ambient `src/**/*.d.{ts,mts,cts}` files in the program; inherited `include` / `exclude` / `declarationDir` / `composite` / `incremental` are overridden so the package's own tsconfig cannot defeat the restriction or redirect output.
- The temporary tsgo config is written in the project directory, fixing declaration generation for packages whose only `tsconfig.json` lives in an ancestor directory (previously TS18003).
- Watch mode now generates declarations even with `--silent` (only logging is suppressed).

## Why

- WillBoosterLab/llm-proxy#775 needed declarations only for `src/routes.ts` and had to run `tsc --emitDeclarationOnly` plus a 50-line prune script, and `mv dist ../../dist/shared` for the shared package, because build-ts hardcoded `dist/` and always emitted declarations for all of `src/`.
- WillBooster/code-analyzer#438 (and #433) builds `../../dist/types` (declaration-only) and `../../dist/runtime` (JS + declarations for one entry) with two custom tsconfig files and raw `tsc`.
- With this PR, those builds become one-line `build-ts lib` invocations (e.g. `build-ts lib --declaration-only --input src/routes.ts --out-dir ../../dist/server`).

## Testing

- Added a test covering `--out-dir`, `--declaration-only`, input-restricted declarations (unreachable files excluded), inherited `declarationDir` / `include` overrides, and the source-protection guard.
- `yarn verify` and `yarn verify-full` pass; each guard and tsconfig-override fix was also reproduced and re-verified via CLI fixtures during multi-agent review (11 rounds, converged with no remaining findings).

## Notes

- Known limitations tracked as issues: cross-package (monorepo) declaration generation fails with `TS6059` (#666), pre-existing non-package directories passed as `--out-dir` are still deleted (#667), and files imported only by ambient declarations also emit declarations (#668).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
