### PR TITLE
feat: support glob patterns in --input

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,22 +73,22 @@ npx build-ts run src/main.ts -- --foo bar
 
 ### Common build options (`app`, `functions`, and `lib`)
 
-| Option                           | Alias | Default  | Description                                                                                                 |
-| -------------------------------- | ----- | -------- | ----------------------------------------------------------------------------------------------------------- |
-| `--input`                        | `-i`  | (auto)   | Source files to build. The first file is the main entry. Defaults to `src/index.{ts,tsx,cts,mts}`.          |
-| `--out-dir`                      | `-o`  | `dist`   | Output directory, resolved from the current directory (e.g., `../../dist/shared`). Removed before building. |
-| `--module-type`                  | `-m`  | (varies) | Output module format: `esm`, `cjs`, `either` (follow `package.json`'s `type`), or `both` (`lib` only).      |
-| `--minify` / `--no-minify`       |       | `true`   | Enable/disable minification.                                                                                |
-| `--sourcemap` / `--no-sourcemap` |       | `true`   | Enable/disable sourcemaps.                                                                                  |
-| `--watch`                        | `-w`  | `false`  | Rebuild on file changes.                                                                                    |
-| `--external`                     |       |          | Additional dependencies to keep external (not bundled).                                                     |
-| `--core-js`                      |       | `false`  | Inject `core-js` polyfills via Babel.                                                                       |
-| `--core-js-proposals`            |       | `false`  | Inject `core-js` polyfills including proposals via Babel.                                                   |
-| `--inline`                       |       |          | Names of environment variables to inline into the bundle.                                                   |
-| `--auto-inline`                  |       | `false`  | Inline all environment variables defined in `.env` files.                                                   |
-| `--keep-import`                  |       |          | Identifiers to keep as import statements.                                                                   |
-| `--bundle-builtins`              |       |          | Module names that shadow Node.js builtins (e.g., `undici`) to be bundled.                                   |
-| `--silent`                       | `-s`  | `false`  | Suppress non-error output.                                                                                  |
+| Option                           | Alias | Default  | Description                                                                                                                              |
+| -------------------------------- | ----- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `--input`                        | `-i`  | (auto)   | Source files (or glob patterns like `src/**/*.ts`) to build. The first file is the main entry. Defaults to `src/index.{ts,tsx,cts,mts}`. |
+| `--out-dir`                      | `-o`  | `dist`   | Output directory, resolved from the current directory (e.g., `../../dist/shared`). Removed before building.                              |
+| `--module-type`                  | `-m`  | (varies) | Output module format: `esm`, `cjs`, `either` (follow `package.json`'s `type`), or `both` (`lib` only).                                   |
+| `--minify` / `--no-minify`       |       | `true`   | Enable/disable minification.                                                                                                             |
+| `--sourcemap` / `--no-sourcemap` |       | `true`   | Enable/disable sourcemaps.                                                                                                               |
+| `--watch`                        | `-w`  | `false`  | Rebuild on file changes.                                                                                                                 |
+| `--external`                     |       |          | Additional dependencies to keep external (not bundled).                                                                                  |
+| `--core-js`                      |       | `false`  | Inject `core-js` polyfills via Babel.                                                                                                    |
+| `--core-js-proposals`            |       | `false`  | Inject `core-js` polyfills including proposals via Babel.                                                                                |
+| `--inline`                       |       |          | Names of environment variables to inline into the bundle.                                                                                |
+| `--auto-inline`                  |       | `false`  | Inline all environment variables defined in `.env` files.                                                                                |
+| `--keep-import`                  |       |          | Identifiers to keep as import statements.                                                                                                |
+| `--bundle-builtins`              |       |          | Module names that shadow Node.js builtins (e.g., `undici`) to be bundled.                                                                |
+| `--silent`                       | `-s`  | `false`  | Suppress non-error output.                                                                                                               |
 
 ### `functions`-specific options
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ npx build-ts run src/main.ts -- --foo bar
 | `--bundle-builtins`              |       |          | Module names that shadow Node.js builtins (e.g., `undici`) to be bundled.                                                                |
 | `--silent`                       | `-s`  | `false`  | Suppress non-error output.                                                                                                               |
 
+Glob patterns in `--input` are expanded with matches sorted alphabetically, and a path that names an existing file is always taken literally. Two caveats: in watch mode, patterns are expanded only once at startup, so files created later are not picked up until a restart; and for the `functions` target, the main entry (`index`) is the first match, so prefer listing the main entry explicitly (entry-name conflicts fail the build).
+
 ### `functions`-specific options
 
 | Option                | Alias | Default | Description                                             |

--- a/src/commands/build/build.ts
+++ b/src/commands/build/build.ts
@@ -400,9 +400,12 @@ function containsPath(parentPath: string, childPath: string): boolean {
 function isBundlerResolvablePath(literalPath: string): boolean {
   const extension = path.extname(literalPath);
   const aliasedExtensions = { '.cjs': ['.cts'], '.js': ['.ts', '.tsx'], '.mjs': ['.mts'] }[extension] ?? [];
+  const extensions = ['.cts', '.mts', '.ts', '.tsx', '.cjs', '.mjs', '.js', '.jsx', '.json'];
   const candidates = [
-    ...['.cts', '.mts', '.ts', '.tsx', '.cjs', '.mjs', '.js', '.jsx', '.json'].map((ext) => literalPath + ext),
+    ...extensions.map((ext) => literalPath + ext),
     ...aliasedExtensions.map((ext) => literalPath.slice(0, -extension.length) + ext),
+    // The bundler also resolves a directory to its index file.
+    ...extensions.map((ext) => path.join(literalPath, `index${ext}`)),
   ];
   return candidates.some((candidate) => fs.statSync(candidate, { throwIfNoEntry: false })?.isFile());
 }

--- a/src/commands/build/build.ts
+++ b/src/commands/build/build.ts
@@ -145,11 +145,7 @@ export async function build(argv: ArgumentsType<AnyBuilderType>, targetCategory:
     checks: { preferBuiltinFeature: false },
     external: createExternalMatcher(argv, targetDetail, packageJson, namespace, packageDirPath),
     input:
-      targetDetail === 'functions'
-        ? Object.fromEntries(
-            inputs.map((input, index) => [index === 0 ? 'index' : path.basename(input, path.extname(input)), input])
-          )
-        : inputs,
+      targetDetail === 'functions' ? createFunctionsInputEntries(inputs) : inputs,
     plugins: setupPlugins(argv, outputOptionsList, packageDirPath),
     resolve: {
       extensionAlias: {
@@ -400,6 +396,21 @@ function containsPath(parentPath: string, childPath: string): boolean {
   return relativePath !== '..' && !relativePath.startsWith(`..${path.sep}`);
 }
 
+function createFunctionsInputEntries(inputs: string[]): Record<string, string> {
+  const entries: Record<string, string> = {};
+  for (const [index, input] of inputs.entries()) {
+    const name = index === 0 ? 'index' : path.basename(input, path.extname(input));
+    if (entries[name]) {
+      console.error(
+        `Entry names conflict in the functions build: "${name}" (${entries[name]} vs ${input}). List --input files explicitly with unique base names, keeping the main entry first.`
+      );
+      process.exit(1);
+    }
+    entries[name] = input;
+  }
+  return entries;
+}
+
 function getInputFiles(input: RolldownOptions['input']): string[] {
   if (!input) return [];
   if (typeof input === 'string') return [input];
@@ -409,20 +420,29 @@ function getInputFiles(input: RolldownOptions['input']): string[] {
 function verifyInput(argv: ArgumentsType<typeof builder>, cwd: string, packageDirPath: string): string[] {
   if (argv.input && argv.input.length > 0) {
     const inputs = argv.input.flatMap((p) => {
-      const pattern = p.toString();
-      if (!/[*?{[]/.test(pattern)) return [path.resolve(cwd, pattern)];
+      const raw = p.toString();
+      // An existing file always wins over glob interpretation (e.g. "src/entry[1].ts").
+      const literalPath = path.resolve(cwd, raw);
+      if (fs.existsSync(literalPath)) return [literalPath];
 
+      // `fs.globSync` requires "/" as the separator even on Windows (a no-op on POSIX).
+      const pattern = raw.split(path.sep).join('/');
       // Ambient declaration files always participate in type checking, so they must not become entries.
+      // `throwIfNoEntry: false` skips broken symlinks instead of crashing.
       const matches = fs
         .globSync(pattern, { cwd })
-        .filter((m) => !/\.d\.[cm]?ts$/.test(m) && fs.statSync(path.resolve(cwd, m)).isFile())
+        .filter(
+          (m) => !/\.d\.[cm]?ts$/.test(m) && fs.statSync(path.resolve(cwd, m), { throwIfNoEntry: false })?.isFile()
+        )
         .sort()
         .map((m) => path.resolve(cwd, m));
-      if (matches.length === 0) {
-        console.error(`No files matched the input pattern: ${pattern}`);
+      if (matches.length > 0) return matches;
+      if (/[*?{[(!@+]/.test(raw)) {
+        console.error(`No files matched the input pattern: ${raw}`);
         process.exit(1);
       }
-      return matches;
+      // A non-existing non-pattern path may still be resolvable by the bundler (e.g. an extension-less path).
+      return [literalPath];
     });
     return [...new Set(inputs)];
   }

--- a/src/commands/build/build.ts
+++ b/src/commands/build/build.ts
@@ -438,9 +438,9 @@ function verifyInput(argv: ArgumentsType<typeof builder>, cwd: string, packageDi
         .sort()
         .map((m) => path.resolve(cwd, m));
       if (matches.length > 0) return matches;
-      // Error only on actual glob syntax ("*", "?", "[...]", "{...}", or extglob "@(...)" etc.);
-      // characters like a bare "+" or "@" are ordinary filename characters.
-      if (/[*?]|[@!+]\(|\[.*\]|\{.*\}/.test(raw)) {
+      // Error only on actual glob syntax ("*", "?", "[...]", alternation/range braces, or extglob "@(...)" etc.);
+      // characters like a bare "+" or a single-item brace ("{entry}") are ordinary filename characters.
+      if (/[*?]|[@!+]\(|\[.*\]|\{[^}]*(,|\.\.)[^}]*\}/.test(raw)) {
         console.error(`No files matched the input pattern: ${raw}`);
         process.exit(1);
       }

--- a/src/commands/build/build.ts
+++ b/src/commands/build/build.ts
@@ -400,12 +400,9 @@ function containsPath(parentPath: string, childPath: string): boolean {
 function isBundlerResolvablePath(literalPath: string): boolean {
   const extension = path.extname(literalPath);
   const aliasedExtensions = { '.cjs': ['.cts'], '.js': ['.ts', '.tsx'], '.mjs': ['.mts'] }[extension] ?? [];
-  const extensions = ['.cts', '.mts', '.ts', '.tsx', '.cjs', '.mjs', '.js', '.jsx', '.json'];
   const candidates = [
-    ...extensions.map((ext) => literalPath + ext),
+    ...['.cts', '.mts', '.ts', '.tsx', '.cjs', '.mjs', '.js', '.jsx', '.json'].map((ext) => literalPath + ext),
     ...aliasedExtensions.map((ext) => literalPath.slice(0, -extension.length) + ext),
-    // The bundler also resolves a directory to its index file.
-    ...extensions.map((ext) => path.join(literalPath, `index${ext}`)),
   ];
   return candidates.some((candidate) => fs.statSync(candidate, { throwIfNoEntry: false })?.isFile());
 }
@@ -439,7 +436,8 @@ function verifyInput(argv: ArgumentsType<typeof builder>, cwd: string, packageDi
       // An existing file always wins over glob interpretation (e.g. "src/entry[1].ts"), but a
       // directory must not, so that a directory literally named like a pattern still expands.
       const literalPath = path.resolve(cwd, raw);
-      if (fs.statSync(literalPath, { throwIfNoEntry: false })?.isFile()) return [literalPath];
+      const literalStats = fs.statSync(literalPath, { throwIfNoEntry: false });
+      if (literalStats?.isFile()) return [literalPath];
 
       // `fs.globSync` requires "/" as the separator even on Windows (a no-op on POSIX).
       const pattern = raw.split(path.sep).join('/');
@@ -453,6 +451,9 @@ function verifyInput(argv: ArgumentsType<typeof builder>, cwd: string, packageDi
         .sort()
         .map((m) => path.resolve(cwd, m));
       if (matches.length > 0) return matches;
+      // Once no file matched, an existing directory is left to the bundler, which resolves it
+      // through its "index" file or its package.json entry fields.
+      if (literalStats?.isDirectory()) return [literalPath];
       // A non-existing path may still be resolvable by the bundler (e.g. an extension-less path or a
       // ".js" specifier aliased to ".ts"), even when it contains glob metacharacters.
       if (isBundlerResolvablePath(literalPath)) return [literalPath];

--- a/src/commands/build/build.ts
+++ b/src/commands/build/build.ts
@@ -397,7 +397,8 @@ function containsPath(parentPath: string, childPath: string): boolean {
 }
 
 function createFunctionsInputEntries(inputs: string[]): Record<string, string> {
-  const entries: Record<string, string> = {};
+  // A null prototype avoids false conflicts with inherited members (e.g. an entry named "toString").
+  const entries: Record<string, string> = Object.create(null);
   for (const [index, input] of inputs.entries()) {
     const name = index === 0 ? 'index' : path.basename(input, path.extname(input));
     if (entries[name]) {

--- a/src/commands/build/build.ts
+++ b/src/commands/build/build.ts
@@ -438,7 +438,9 @@ function verifyInput(argv: ArgumentsType<typeof builder>, cwd: string, packageDi
         .sort()
         .map((m) => path.resolve(cwd, m));
       if (matches.length > 0) return matches;
-      if (/[*?{[(!@+]/.test(raw)) {
+      // Error only on actual glob syntax ("*", "?", "[...]", "{...}", or extglob "@(...)" etc.);
+      // characters like a bare "+" or "@" are ordinary filename characters.
+      if (/[*?]|[@!+]\(|\[.*\]|\{.*\}/.test(raw)) {
         console.error(`No files matched the input pattern: ${raw}`);
         process.exit(1);
       }

--- a/src/commands/build/build.ts
+++ b/src/commands/build/build.ts
@@ -404,7 +404,7 @@ function isBundlerResolvablePath(literalPath: string): boolean {
     ...['.cts', '.mts', '.ts', '.tsx', '.cjs', '.mjs', '.js', '.jsx', '.json'].map((ext) => literalPath + ext),
     ...aliasedExtensions.map((ext) => literalPath.slice(0, -extension.length) + ext),
   ];
-  return candidates.some((candidate) => fs.existsSync(candidate));
+  return candidates.some((candidate) => fs.statSync(candidate, { throwIfNoEntry: false })?.isFile());
 }
 
 function createFunctionsInputEntries(inputs: string[]): Record<string, string> {

--- a/src/commands/build/build.ts
+++ b/src/commands/build/build.ts
@@ -433,9 +433,10 @@ function verifyInput(argv: ArgumentsType<typeof builder>, cwd: string, packageDi
   if (argv.input && argv.input.length > 0) {
     const inputs = argv.input.flatMap((p) => {
       const raw = p.toString();
-      // An existing file always wins over glob interpretation (e.g. "src/entry[1].ts").
+      // An existing file always wins over glob interpretation (e.g. "src/entry[1].ts"), but a
+      // directory must not, so that a directory literally named like a pattern still expands.
       const literalPath = path.resolve(cwd, raw);
-      if (fs.existsSync(literalPath)) return [literalPath];
+      if (fs.statSync(literalPath, { throwIfNoEntry: false })?.isFile()) return [literalPath];
 
       // `fs.globSync` requires "/" as the separator even on Windows (a no-op on POSIX).
       const pattern = raw.split(path.sep).join('/');

--- a/src/commands/build/build.ts
+++ b/src/commands/build/build.ts
@@ -407,7 +407,25 @@ function getInputFiles(input: RolldownOptions['input']): string[] {
 }
 
 function verifyInput(argv: ArgumentsType<typeof builder>, cwd: string, packageDirPath: string): string[] {
-  if (argv.input && argv.input.length > 0) return argv.input.map((p) => path.resolve(cwd, p.toString()));
+  if (argv.input && argv.input.length > 0) {
+    const inputs = argv.input.flatMap((p) => {
+      const pattern = p.toString();
+      if (!/[*?{[]/.test(pattern)) return [path.resolve(cwd, pattern)];
+
+      // Ambient declaration files always participate in type checking, so they must not become entries.
+      const matches = fs
+        .globSync(pattern, { cwd })
+        .filter((m) => !/\.d\.[cm]?ts$/.test(m) && fs.statSync(path.resolve(cwd, m)).isFile())
+        .sort()
+        .map((m) => path.resolve(cwd, m));
+      if (matches.length === 0) {
+        console.error(`No files matched the input pattern: ${pattern}`);
+        process.exit(1);
+      }
+      return matches;
+    });
+    return [...new Set(inputs)];
+  }
 
   const srcDirPath = path.join(packageDirPath, 'src');
   for (const ext of ['ts', 'tsx', 'cts', 'mts']) {

--- a/src/commands/build/build.ts
+++ b/src/commands/build/build.ts
@@ -396,6 +396,17 @@ function containsPath(parentPath: string, childPath: string): boolean {
   return relativePath !== '..' && !relativePath.startsWith(`..${path.sep}`);
 }
 
+// Mirrors the bundler's `resolve.extensions` / `extensionAlias` configuration above.
+function isBundlerResolvablePath(literalPath: string): boolean {
+  const extension = path.extname(literalPath);
+  const aliasedExtensions = { '.cjs': ['.cts'], '.js': ['.ts', '.tsx'], '.mjs': ['.mts'] }[extension] ?? [];
+  const candidates = [
+    ...['.cts', '.mts', '.ts', '.tsx', '.cjs', '.mjs', '.js', '.jsx', '.json'].map((ext) => literalPath + ext),
+    ...aliasedExtensions.map((ext) => literalPath.slice(0, -extension.length) + ext),
+  ];
+  return candidates.some((candidate) => fs.existsSync(candidate));
+}
+
 function createFunctionsInputEntries(inputs: string[]): Record<string, string> {
   // A null prototype avoids false conflicts with inherited members (e.g. an entry named "toString").
   const entries: Record<string, string> = Object.create(null);
@@ -438,13 +449,15 @@ function verifyInput(argv: ArgumentsType<typeof builder>, cwd: string, packageDi
         .sort()
         .map((m) => path.resolve(cwd, m));
       if (matches.length > 0) return matches;
+      // A non-existing path may still be resolvable by the bundler (e.g. an extension-less path or a
+      // ".js" specifier aliased to ".ts"), even when it contains glob metacharacters.
+      if (isBundlerResolvablePath(literalPath)) return [literalPath];
       // Error only on actual glob syntax ("*", "?", "[...]", alternation/range braces, or extglob "@(...)" etc.);
       // characters like a bare "+" or a single-item brace ("{entry}") are ordinary filename characters.
       if (/[*?]|[@!+]\(|\[.*\]|\{[^}]*(,|\.\.)[^}]*\}/.test(raw)) {
         console.error(`No files matched the input pattern: ${raw}`);
         process.exit(1);
       }
-      // A non-existing non-pattern path may still be resolvable by the bundler (e.g. an extension-less path).
       return [literalPath];
     });
     return [...new Set(inputs)];

--- a/src/commands/build/builder.ts
+++ b/src/commands/build/builder.ts
@@ -4,7 +4,7 @@ export const builder = {
   ...sharedOptionsBuilder,
   input: {
     description:
-      'Paths of source code files to be built. The first file is main. If no option is given, "src/index.{ts,tsx,cts,mts}" from package directory is targeted.',
+      'Paths or glob patterns (e.g. "src/**/*.ts") of source code files to be built. The first file is main. If no option is given, "src/index.{ts,tsx,cts,mts}" from package directory is targeted.',
     type: 'array',
     alias: 'i',
   },

--- a/test/build.test.ts
+++ b/test/build.test.ts
@@ -1715,6 +1715,20 @@ export const routes = { helper };
       literalOutDirPath
     );
     expect(fs.readdirSync(literalOutDirPath)).toEqual(['entry[1].d.ts']);
+
+    // A directory named like a pattern must not shadow glob expansion.
+    await fs.promises.mkdir(`${fixtureDirPath}/src/*.ts`, { recursive: true });
+    const directoryOutDirPath = '.tmp/test-fixtures/lib-glob-input-directory';
+    await buildWithPackagePath(
+      fixtureDirPath,
+      'lib',
+      '--declaration-only',
+      '--input',
+      `${fixtureDirPath}/src/*.ts`,
+      '--out-dir',
+      directoryOutDirPath
+    );
+    expect(fs.readdirSync(directoryOutDirPath).toSorted()).toContain('schemas.d.ts');
   });
 
   it('functions fails on conflicting entry names instead of silently dropping one', async () => {

--- a/test/build.test.ts
+++ b/test/build.test.ts
@@ -1643,6 +1643,62 @@ export const routes = { helper };
     expect(fs.existsSync(`${fixtureDirPath}/src/routes.ts`)).toBe(true);
   });
 
+  it('lib with glob --input builds every matched module as an entry', async () => {
+    const fixtureDirPath = '.tmp/test-fixtures/lib-glob-input';
+    await fs.promises.rm(fixtureDirPath, { recursive: true, force: true });
+    await fs.promises.mkdir(`${fixtureDirPath}/src/sub`, { recursive: true });
+    await fs.promises.writeFile(
+      `${fixtureDirPath}/package.json`,
+      JSON.stringify({
+        type: 'module',
+        packageManager: 'yarn@4.17.0',
+      })
+    );
+    await fs.promises.writeFile(`${fixtureDirPath}/yarn.lock`, '');
+    await fs.promises.writeFile(
+      `${fixtureDirPath}/tsconfig.json`,
+      JSON.stringify({
+        compilerOptions: {
+          module: 'esnext',
+          moduleResolution: 'bundler',
+          strict: true,
+          target: 'es2022',
+        },
+        include: ['src/**/*'],
+      })
+    );
+    await fs.promises.writeFile(`${fixtureDirPath}/src/index.ts`, 'export function main(): number {\n  return 1;\n}\n');
+    // Not imported from index.ts, so a single-entry build would drop its exports.
+    await fs.promises.writeFile(`${fixtureDirPath}/src/schemas.ts`, 'export const schema = { id: 1 };\n');
+    await fs.promises.writeFile(
+      `${fixtureDirPath}/src/sub/util.ts`,
+      'export function util(): number {\n  return 2;\n}\n'
+    );
+    await fs.promises.writeFile(`${fixtureDirPath}/src/ambient.d.ts`, 'declare const AMBIENT: string;\n');
+
+    await buildWithPackagePath(
+      fixtureDirPath,
+      'lib',
+      '--module-type',
+      'esm',
+      '--input',
+      `${fixtureDirPath}/src/**/*.ts`
+    );
+
+    await expectFileExists(`${fixtureDirPath}/dist/index.js`);
+    await expectFileExists(`${fixtureDirPath}/dist/schemas.js`);
+    await expectFileExists(`${fixtureDirPath}/dist/schemas.d.ts`);
+    await expectFileExists(`${fixtureDirPath}/dist/sub/util.js`);
+    expect(fs.existsSync(`${fixtureDirPath}/dist/ambient.js`)).toBe(false);
+
+    const ret = await spawnAsync(
+      'node',
+      ['-e', "import('./dist/schemas.js').then((mod) => process.exit(mod.schema.id === 1 ? 0 : 1))"],
+      { cwd: fixtureDirPath }
+    );
+    expect(ret.status).toBe(0);
+  });
+
   it('lib-react-ts-entry', async () => {
     const dirName = 'lib-react-ts-entry';
     await buildWithCommand(dirName, 'lib', '--module-type', 'both');

--- a/test/build.test.ts
+++ b/test/build.test.ts
@@ -1675,6 +1675,8 @@ export const routes = { helper };
       'export function util(): number {\n  return 2;\n}\n'
     );
     await fs.promises.writeFile(`${fixtureDirPath}/src/ambient.d.ts`, 'declare const AMBIENT: string;\n');
+    // A broken symlink matched by the glob must be skipped, not crash the build.
+    await fs.promises.symlink('missing.ts', `${fixtureDirPath}/src/broken.ts`);
 
     await buildWithPackagePath(
       fixtureDirPath,
@@ -1690,6 +1692,7 @@ export const routes = { helper };
     await expectFileExists(`${fixtureDirPath}/dist/schemas.d.ts`);
     await expectFileExists(`${fixtureDirPath}/dist/sub/util.js`);
     expect(fs.existsSync(`${fixtureDirPath}/dist/ambient.js`)).toBe(false);
+    expect(fs.existsSync(`${fixtureDirPath}/dist/broken.js`)).toBe(false);
 
     const ret = await spawnAsync(
       'node',
@@ -1697,6 +1700,48 @@ export const routes = { helper };
       { cwd: fixtureDirPath }
     );
     expect(ret.status).toBe(0);
+
+    // A path that names an existing file must be taken literally even when it contains glob metacharacters.
+    await fs.promises.writeFile(`${fixtureDirPath}/src/entry[1].ts`, 'export const literal = true;\n');
+    await fs.promises.writeFile(`${fixtureDirPath}/src/entry1.ts`, 'export const globbed = true;\n');
+    const literalOutDirPath = '.tmp/test-fixtures/lib-glob-input-literal';
+    await buildWithPackagePath(
+      fixtureDirPath,
+      'lib',
+      '--declaration-only',
+      '--input',
+      `${fixtureDirPath}/src/entry[1].ts`,
+      '--out-dir',
+      literalOutDirPath
+    );
+    expect(fs.readdirSync(literalOutDirPath)).toEqual(['entry[1].d.ts']);
+  });
+
+  it('functions fails on conflicting entry names instead of silently dropping one', async () => {
+    const fixtureDirPath = '.tmp/test-fixtures/functions-conflicting-entries';
+    await fs.promises.rm(fixtureDirPath, { recursive: true, force: true });
+    await fs.promises.mkdir(`${fixtureDirPath}/src/one`, { recursive: true });
+    await fs.promises.mkdir(`${fixtureDirPath}/src/two`, { recursive: true });
+    await fs.promises.writeFile(
+      `${fixtureDirPath}/package.json`,
+      JSON.stringify({ type: 'module', packageManager: 'yarn@4.17.0' })
+    );
+    await fs.promises.writeFile(`${fixtureDirPath}/yarn.lock`, '');
+    await fs.promises.writeFile(`${fixtureDirPath}/src/index.ts`, 'export const main = 1;\n');
+    await fs.promises.writeFile(`${fixtureDirPath}/src/one/handler.ts`, 'export const marker = "one";\n');
+    await fs.promises.writeFile(`${fixtureDirPath}/src/two/handler.ts`, 'export const marker = "two";\n');
+
+    const ret = await buildWithPackagePathAndGetStatus(
+      fixtureDirPath,
+      'functions',
+      '--input',
+      `${fixtureDirPath}/src/index.ts`,
+      '--input',
+      `${fixtureDirPath}/src/one/handler.ts`,
+      '--input',
+      `${fixtureDirPath}/src/two/handler.ts`
+    );
+    expect(ret.status).not.toBe(0);
   });
 
   it('lib-react-ts-entry', async () => {

--- a/test/build.test.ts
+++ b/test/build.test.ts
@@ -1717,18 +1717,19 @@ export const routes = { helper };
     expect(fs.readdirSync(literalOutDirPath)).toEqual(['entry[1].d.ts']);
 
     // A directory named like a pattern must not shadow glob expansion.
-    await fs.promises.mkdir(`${fixtureDirPath}/src/*.ts`, { recursive: true });
+    // "[s]chemas.ts" keeps the fixture portable: Windows forbids "*" in names but allows "[]".
+    await fs.promises.mkdir(`${fixtureDirPath}/src/[s]chemas.ts`, { recursive: true });
     const directoryOutDirPath = '.tmp/test-fixtures/lib-glob-input-directory';
     await buildWithPackagePath(
       fixtureDirPath,
       'lib',
       '--declaration-only',
       '--input',
-      `${fixtureDirPath}/src/*.ts`,
+      `${fixtureDirPath}/src/[s]chemas.ts`,
       '--out-dir',
       directoryOutDirPath
     );
-    expect(fs.readdirSync(directoryOutDirPath).toSorted()).toContain('schemas.d.ts');
+    expect(fs.readdirSync(directoryOutDirPath)).toEqual(['schemas.d.ts']);
   });
 
   it('functions fails on conflicting entry names instead of silently dropping one', async () => {

--- a/test/build.test.ts
+++ b/test/build.test.ts
@@ -1730,6 +1730,21 @@ export const routes = { helper };
       directoryOutDirPath
     );
     expect(fs.readdirSync(directoryOutDirPath)).toEqual(['schemas.d.ts']);
+
+    // A directory entry whose name contains glob metacharacters still resolves to its index file.
+    // Declarations are not generated here because tsgo cannot take a directory as an entry.
+    await fs.promises.mkdir(`${fixtureDirPath}/src/[b]racket`, { recursive: true });
+    await fs.promises.writeFile(`${fixtureDirPath}/src/[b]racket/index.ts`, 'export const bracket = true;\n');
+    const directoryEntryOutDirPath = '.tmp/test-fixtures/lib-glob-input-directory-entry';
+    await buildWithPackagePath(
+      fixtureDirPath,
+      'app',
+      '--input',
+      `${fixtureDirPath}/src/[b]racket`,
+      '--out-dir',
+      directoryEntryOutDirPath
+    );
+    await expectFileExists(`${directoryEntryOutDirPath}/index.js`);
   });
 
   it('functions fails on conflicting entry names instead of silently dropping one', async () => {


### PR DESCRIPTION
## Why

Building a library whose package `exports` expose every module via a wildcard (e.g. `"./shared/*": "./dist/shared/*.js"`) requires every source file to be a bundling entry: with a single entry, Rolldown's tree-shaking drops exports that are not reachable from it. For example, `llm-proxy`'s `shared` package loses 5 of its 35 runtime exports in `schemas.js` when only `src/index.ts` is the entry.

## What

- `--input` now accepts glob patterns (e.g. `src/**/*.ts`), expanded via Node's `fs.globSync` with matches sorted alphabetically, so all modules can be listed as entries without enumerating them.
- Ambient declaration files (`*.d.ts` / `*.d.mts` / `*.d.cts`) matched by a pattern are excluded, and broken symlinks are skipped rather than crashing the build.
- Resolution order for each `--input` value: an existing **file** wins over glob interpretation (so `src/entry[1].ts` stays literal), then glob expansion, then an existing **directory** (left to the bundler, which resolves it via `index.*` or its `package.json` entry fields), then a path the bundler can still resolve through its configured extensions / extension aliases (e.g. an extension-less `src/entry+name`). Only when none of those apply does an actual glob pattern fail with an explicit `No files matched the input pattern` error.
- Patterns are normalized to `/` separators, which `fs.globSync` requires even on Windows.
- The `functions` target now fails on conflicting entry names instead of silently dropping an entry (previously `Object.fromEntries` let a later `src/two/handler.ts` overwrite `src/one/handler.ts`). The entry map has a null prototype so base names like `toString` are not treated as conflicts.

## Documentation

The README documents the sorted expansion, the literal-file precedence, the `functions` main-entry caveat, and the watch-mode limitation below.

## Known limitations (tracked separately)

- Watch mode expands patterns only once at startup, so files created later need a restart: [#670](https://github.com/WillBooster/build-ts/issues/670).
- `lib` declaration generation cannot take a directory or a `.js`-aliased input (pre-existing, reproduced on `main`): [#671](https://github.com/WillBooster/build-ts/issues/671).

## Testing

- New tests: glob expansion as entries (covering ambient declarations, broken symlinks, literal metacharacter filenames, a directory named like a pattern, and a directory entry whose name contains metacharacters) and the `functions` entry-name conflict.
- `yarn test` (59 passed) and `yarn verify` pass.
- Verified against `llm-proxy`'s `shared` package: `build-ts lib --module-type esm --input 'src/**/*.ts' --out-dir ../../dist/shared` restores all 35 exports of `schemas.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
