### PR TITLE
fix: generate declarations for directory and extension-aliased lib in…

### DIFF
--- a/src/commands/build/build.ts
+++ b/src/commands/build/build.ts
@@ -17,6 +17,7 @@ import type { AnyBuilderType, builder } from './builder.js';
 import { appBuilder, functionsBuilder, libBuilder } from './builder.js';
 import { handleError } from './bundlerLogger.js';
 import { createExternalMatcher } from './externals.js';
+import { bundlerExtensionAlias, bundlerExtensions, resolveSourceFilePath } from './inputResolver.js';
 import { setupPlugins } from './plugin.js';
 import { generateDeclarationFiles } from './typeScript.js';
 
@@ -81,8 +82,13 @@ export async function build(argv: ArgumentsType<AnyBuilderType>, targetCategory:
   const targetDetail = detectTargetDetail(targetCategory, inputs, packageDirPath);
   const outDirPath = resolveOutDirPath(argv, cwd, packageDirPath, inputs, targetCategory);
   // Restrict declaration files to the entry files (and their imports) only when inputs are explicit,
-  // to keep the default behavior of emitting declarations for all files under src/.
-  const declarationInputs = argv.input?.length ? inputs : undefined;
+  // to keep the default behavior of emitting declarations for all files under src/. tsc cannot take a
+  // bundler-style entry (a directory, or a ".js" specifier aliased to a ".ts" source) literally, so
+  // each one is resolved to the source file it refers to; an unresolvable path is kept as is to let
+  // the compiler report it.
+  const declarationInputs = argv.input?.length
+    ? [...new Set(inputs.map((input) => resolveSourceFilePath(input) ?? input))]
+    : undefined;
 
   if (verbose) {
     console.info('argv:', argv);
@@ -147,14 +153,7 @@ export async function build(argv: ArgumentsType<AnyBuilderType>, targetCategory:
     input:
       targetDetail === 'functions' ? createFunctionsInputEntries(inputs) : inputs,
     plugins: setupPlugins(argv, outputOptionsList, packageDirPath),
-    resolve: {
-      extensionAlias: {
-        '.cjs': ['.cjs', '.cts'],
-        '.js': ['.js', '.ts', '.tsx'],
-        '.mjs': ['.mjs', '.mts'],
-      },
-      extensions: ['.cts', '.mts', '.ts', '.tsx', '.cjs', '.mjs', '.js', '.jsx', '.json'],
-    },
+    resolve: { extensionAlias: bundlerExtensionAlias, extensions: bundlerExtensions },
     treeshake: argv['core-js'] || argv['core-js-proposals'] ? false : undefined,
     transform: getTransformOptions(argv, packageDirPath),
     watch: argv.watch ? { clearScreen: false } : undefined,
@@ -396,17 +395,6 @@ function containsPath(parentPath: string, childPath: string): boolean {
   return relativePath !== '..' && !relativePath.startsWith(`..${path.sep}`);
 }
 
-// Mirrors the bundler's `resolve.extensions` / `extensionAlias` configuration above.
-function isBundlerResolvablePath(literalPath: string): boolean {
-  const extension = path.extname(literalPath);
-  const aliasedExtensions = { '.cjs': ['.cts'], '.js': ['.ts', '.tsx'], '.mjs': ['.mts'] }[extension] ?? [];
-  const candidates = [
-    ...['.cts', '.mts', '.ts', '.tsx', '.cjs', '.mjs', '.js', '.jsx', '.json'].map((ext) => literalPath + ext),
-    ...aliasedExtensions.map((ext) => literalPath.slice(0, -extension.length) + ext),
-  ];
-  return candidates.some((candidate) => fs.statSync(candidate, { throwIfNoEntry: false })?.isFile());
-}
-
 function createFunctionsInputEntries(inputs: string[]): Record<string, string> {
   // A null prototype avoids false conflicts with inherited members (e.g. an entry named "toString").
   const entries: Record<string, string> = Object.create(null);
@@ -456,7 +444,7 @@ function verifyInput(argv: ArgumentsType<typeof builder>, cwd: string, packageDi
       if (literalStats?.isDirectory()) return [literalPath];
       // A non-existing path may still be resolvable by the bundler (e.g. an extension-less path or a
       // ".js" specifier aliased to ".ts"), even when it contains glob metacharacters.
-      if (isBundlerResolvablePath(literalPath)) return [literalPath];
+      if (resolveSourceFilePath(literalPath)) return [literalPath];
       // Error only on actual glob syntax ("*", "?", "[...]", alternation/range braces, or extglob "@(...)" etc.);
       // characters like a bare "+" or a single-item brace ("{entry}") are ordinary filename characters.
       if (/[*?]|[@!+]\(|\[.*\]|\{[^}]*(,|\.\.)[^}]*\}/.test(raw)) {

--- a/src/commands/build/build.ts
+++ b/src/commands/build/build.ts
@@ -17,7 +17,13 @@ import type { AnyBuilderType, builder } from './builder.js';
 import { appBuilder, functionsBuilder, libBuilder } from './builder.js';
 import { handleError } from './bundlerLogger.js';
 import { createExternalMatcher } from './externals.js';
-import { bundlerResolveOptions, createBundlerResolver, resolveSourceFilePath } from './inputResolver.js';
+import type { BundlerPlatform } from './inputResolver.js';
+import {
+  bundlerResolveOptions,
+  createBundlerResolvers,
+  isBundlerResolvablePath,
+  resolveSourceFilePaths,
+} from './inputResolver.js';
 import { setupPlugins } from './plugin.js';
 import { generateDeclarationFiles } from './typeScript.js';
 
@@ -81,7 +87,6 @@ export async function build(argv: ArgumentsType<AnyBuilderType>, targetCategory:
   const inputs = verifyInput(argv, cwd, packageDirPath);
   const targetDetail = detectTargetDetail(targetCategory, inputs, packageDirPath);
   const outDirPath = resolveOutDirPath(argv, cwd, packageDirPath, inputs, targetCategory);
-  const declarationInputs = resolveDeclarationInputs(argv, inputs);
 
   if (verbose) {
     console.info('argv:', argv);
@@ -118,6 +123,10 @@ export async function build(argv: ArgumentsType<AnyBuilderType>, targetCategory:
     console.error('Failed to detect output files.');
     process.exit(1);
   }
+
+  // The bundler resolves per output format, so declarations must cover every platform in play.
+  const platforms = outputOptionsList.map((opts): BundlerPlatform => (opts.format === 'commonjs' ? 'node' : 'browser'));
+  const declarationInputs = resolveDeclarationInputs(argv, inputs, platforms);
 
   process.chdir(packageDirPath);
   await fs.promises.rm(outDirPath, { recursive: true, force: true });
@@ -173,6 +182,7 @@ export async function build(argv: ArgumentsType<AnyBuilderType>, targetCategory:
       packageDirPath,
       outDirPath,
       inputs,
+      platforms,
       options,
       outputOptionsList,
       pathToRelativePath,
@@ -232,6 +242,7 @@ function watchRolldown(
   packageDirPath: string,
   outDirPath: string,
   inputs: string[],
+  platforms: BundlerPlatform[],
   options: RolldownOptions,
   outputOptionsList: OutputOptions[],
   pathToRelativePath: (paths: string | Readonly<string[]>) => string[],
@@ -289,7 +300,12 @@ function watchRolldown(
             // The bundler re-resolves its literal inputs on every rebuild, so the declaration inputs
             // are resolved again here; reusing the initial list would describe the previous sources
             // after an entry (e.g. a package entry field) started resolving elsewhere.
-            await generateDeclarationFiles(argv, packageDirPath, outDirPath, resolveDeclarationInputs(argv, inputs));
+            await generateDeclarationFiles(
+              argv,
+              packageDirPath,
+              outDirPath,
+              resolveDeclarationInputs(argv, inputs, platforms)
+            );
           }
           break;
         }
@@ -414,13 +430,22 @@ function createFunctionsInputEntries(inputs: string[]): Record<string, string> {
 // compiler report it. Resolution depends on the file system, so a watch rebuild has to redo it.
 function resolveDeclarationInputs(
   argv: ArgumentsType<AnyBuilderType>,
-  inputs: string[]
+  inputs: string[],
+  platforms: BundlerPlatform[]
 ): string[] | undefined {
   if (!argv.input?.length) return undefined;
-  // One resolver serves the whole pass: its cache is consistent within a build but never stale
-  // across rebuilds, since each call creates a new one.
-  const resolver = createBundlerResolver();
-  return [...new Set(inputs.map((input) => resolveSourceFilePath(input, resolver) ?? input))];
+  // The resolvers serve the whole pass: their caches are consistent within a build but never stale
+  // across rebuilds, since each call creates new ones.
+  const resolvers = createBundlerResolvers(platforms);
+  return [
+    ...new Set(
+      inputs.flatMap((input) => {
+        const resolvedPaths = resolveSourceFilePaths(input, resolvers);
+        // An unresolvable path is kept as is to let the compiler report it.
+        return resolvedPaths.length > 0 ? resolvedPaths : [input];
+      })
+    ),
+  ];
 }
 
 function getInputFiles(input: RolldownOptions['input']): string[] {
@@ -456,7 +481,7 @@ function verifyInput(argv: ArgumentsType<typeof builder>, cwd: string, packageDi
       if (literalStats?.isDirectory()) return [literalPath];
       // A non-existing path may still be resolvable by the bundler (e.g. an extension-less path or a
       // ".js" specifier aliased to ".ts"), even when it contains glob metacharacters.
-      if (resolveSourceFilePath(literalPath)) return [literalPath];
+      if (isBundlerResolvablePath(literalPath)) return [literalPath];
       // Error only on actual glob syntax ("*", "?", "[...]", alternation/range braces, or extglob "@(...)" etc.);
       // characters like a bare "+" or a single-item brace ("{entry}") are ordinary filename characters.
       if (/[*?]|[@!+]\(|\[.*\]|\{[^}]*(,|\.\.)[^}]*\}/.test(raw)) {

--- a/src/commands/build/build.ts
+++ b/src/commands/build/build.ts
@@ -17,7 +17,13 @@ import type { AnyBuilderType, builder } from './builder.js';
 import { appBuilder, functionsBuilder, libBuilder } from './builder.js';
 import { handleError } from './bundlerLogger.js';
 import { createExternalMatcher } from './externals.js';
-import { bundlerExtensionAlias, bundlerExtensions, resolveSourceFilePath } from './inputResolver.js';
+import {
+  bundlerExtensionAlias,
+  bundlerExtensions,
+  bundlerMainFields,
+  bundlerMainFiles,
+  resolveSourceFilePath,
+} from './inputResolver.js';
 import { setupPlugins } from './plugin.js';
 import { generateDeclarationFiles } from './typeScript.js';
 
@@ -153,7 +159,12 @@ export async function build(argv: ArgumentsType<AnyBuilderType>, targetCategory:
     input:
       targetDetail === 'functions' ? createFunctionsInputEntries(inputs) : inputs,
     plugins: setupPlugins(argv, outputOptionsList, packageDirPath),
-    resolve: { extensionAlias: bundlerExtensionAlias, extensions: bundlerExtensions },
+    resolve: {
+      extensionAlias: bundlerExtensionAlias,
+      extensions: bundlerExtensions,
+      mainFields: bundlerMainFields,
+      mainFiles: bundlerMainFiles,
+    },
     treeshake: argv['core-js'] || argv['core-js-proposals'] ? false : undefined,
     transform: getTransformOptions(argv, packageDirPath),
     watch: argv.watch ? { clearScreen: false } : undefined,

--- a/src/commands/build/build.ts
+++ b/src/commands/build/build.ts
@@ -17,13 +17,7 @@ import type { AnyBuilderType, builder } from './builder.js';
 import { appBuilder, functionsBuilder, libBuilder } from './builder.js';
 import { handleError } from './bundlerLogger.js';
 import { createExternalMatcher } from './externals.js';
-import {
-  bundlerExtensionAlias,
-  bundlerExtensions,
-  bundlerMainFields,
-  bundlerMainFiles,
-  resolveSourceFilePath,
-} from './inputResolver.js';
+import { bundlerResolveOptions, createBundlerResolver, resolveSourceFilePath } from './inputResolver.js';
 import { setupPlugins } from './plugin.js';
 import { generateDeclarationFiles } from './typeScript.js';
 
@@ -152,12 +146,7 @@ export async function build(argv: ArgumentsType<AnyBuilderType>, targetCategory:
     input:
       targetDetail === 'functions' ? createFunctionsInputEntries(inputs) : inputs,
     plugins: setupPlugins(argv, outputOptionsList, packageDirPath),
-    resolve: {
-      extensionAlias: bundlerExtensionAlias,
-      extensions: bundlerExtensions,
-      mainFields: bundlerMainFields,
-      mainFiles: bundlerMainFiles,
-    },
+    resolve: bundlerResolveOptions,
     treeshake: argv['core-js'] || argv['core-js-proposals'] ? false : undefined,
     transform: getTransformOptions(argv, packageDirPath),
     watch: argv.watch ? { clearScreen: false } : undefined,
@@ -428,7 +417,10 @@ function resolveDeclarationInputs(
   inputs: string[]
 ): string[] | undefined {
   if (!argv.input?.length) return undefined;
-  return [...new Set(inputs.map((input) => resolveSourceFilePath(input) ?? input))];
+  // One resolver serves the whole pass: its cache is consistent within a build but never stale
+  // across rebuilds, since each call creates a new one.
+  const resolver = createBundlerResolver();
+  return [...new Set(inputs.map((input) => resolveSourceFilePath(input, resolver) ?? input))];
 }
 
 function getInputFiles(input: RolldownOptions['input']): string[] {

--- a/src/commands/build/build.ts
+++ b/src/commands/build/build.ts
@@ -126,7 +126,8 @@ export async function build(argv: ArgumentsType<AnyBuilderType>, targetCategory:
 
   // The bundler resolves per output format, so declarations must cover every platform in play.
   const platforms = outputOptionsList.map((opts): BundlerPlatform => (opts.format === 'commonjs' ? 'node' : 'browser'));
-  const declarationInputs = resolveDeclarationInputs(argv, inputs, platforms);
+  const declaration = resolveDeclarationInputs(argv, inputs, platforms);
+  const declarationInputs = declaration.paths;
   // Explicit inputs that the bundler ignores on every platform leave nothing to declare. Generating
   // anyway would emit declarations for every file under src/, since an empty entry list is no filter.
   const hasNothingToDeclare = declarationInputs?.length === 0;
@@ -145,6 +146,10 @@ export async function build(argv: ArgumentsType<AnyBuilderType>, targetCategory:
           `Generates declaration files → ${styleText('bold', path.relative(packageDirPath, outDirPath))}\non ${packageDirPath} ...`
         )
       );
+    }
+    if (declaration.unresolvedInput) {
+      reportUnresolvedInput(declaration.unresolvedInput);
+      process.exit(1);
     }
     if (!hasNothingToDeclare && !(await generateDeclarationFiles(argv, packageDirPath, outDirPath, declarationInputs))) {
       process.exit(1);
@@ -221,13 +226,15 @@ export async function build(argv: ArgumentsType<AnyBuilderType>, targetCategory:
     await bundle?.close();
     if (buildFailed) process.exit(1);
 
-    if (
-      targetDetail !== 'app-node' &&
-      targetDetail !== 'functions' &&
-      !hasNothingToDeclare &&
-      !(await generateDeclarationFiles(argv, packageDirPath, outDirPath, declarationInputs))
-    ) {
-      process.exit(1);
+    if (targetDetail !== 'app-node' && targetDetail !== 'functions' && !hasNothingToDeclare) {
+      // The bundler reports an unresolvable entry itself, so reaching here means it somehow did not.
+      if (declaration.unresolvedInput) {
+        reportUnresolvedInput(declaration.unresolvedInput);
+        process.exit(1);
+      }
+      if (!(await generateDeclarationFiles(argv, packageDirPath, outDirPath, declarationInputs))) {
+        process.exit(1);
+      }
     }
   }
 }
@@ -304,9 +311,11 @@ function watchRolldown(
             // The bundler re-resolves its literal inputs on every rebuild, so the declaration inputs
             // are resolved again here; reusing the initial list would describe the previous sources
             // after an entry (e.g. a package entry field) started resolving elsewhere.
-            const rebuiltInputs = resolveDeclarationInputs(argv, inputs, platforms);
-            if (rebuiltInputs?.length !== 0) {
-              await generateDeclarationFiles(argv, packageDirPath, outDirPath, rebuiltInputs);
+            const rebuilt = resolveDeclarationInputs(argv, inputs, platforms);
+            if (rebuilt.unresolvedInput) {
+              reportUnresolvedInput(rebuilt.unresolvedInput);
+            } else if (rebuilt.paths?.length !== 0) {
+              await generateDeclarationFiles(argv, packageDirPath, outDirPath, rebuilt.paths);
             }
           }
           break;
@@ -430,22 +439,42 @@ function createFunctionsInputEntries(inputs: string[]): Record<string, string> {
 // bundler-style entry (a directory, or a ".js" specifier aliased to a ".ts" source) literally, so each
 // one is resolved to the source file it refers to; an unresolvable path is kept as is to let the
 // compiler report it. Resolution depends on the file system, so a watch rebuild has to redo it.
+interface DeclarationInputs {
+  /** Undefined restricts nothing, so declarations cover every file under src/. */
+  paths: string[] | undefined;
+  /** Set when the bundler cannot resolve an input for some output platform, which fails its build too. */
+  unresolvedInput: string | undefined;
+}
+
+// Restricts declaration files to the entry files (and their imports) only when inputs are explicit,
+// to keep the default behavior of emitting declarations for all files under src/. tsc cannot take a
+// bundler-style entry (a directory, or a ".js" specifier aliased to a ".ts" source) literally, so each
+// one is resolved to the source file it refers to. Resolution depends on the file system, so a watch
+// rebuild has to redo it.
 function resolveDeclarationInputs(
   argv: ArgumentsType<AnyBuilderType>,
   inputs: string[],
   platforms: BundlerPlatform[]
-): string[] | undefined {
-  if (!argv.input?.length) return undefined;
+): DeclarationInputs {
+  if (!argv.input?.length) return { paths: undefined, unresolvedInput: undefined };
+
   // The resolvers serve the whole pass: their caches are consistent within a build but never stale
   // across rebuilds, since each call creates new ones.
   const resolvers = createBundlerResolvers(platforms);
-  return [
-    ...new Set(
-      // An unresolvable path is kept as is to let the compiler report it, whereas a path the bundler
-      // deliberately ignores contributes nothing.
-      inputs.flatMap((input) => resolveSourceFilePaths(input, resolvers) ?? [input])
-    ),
-  ];
+  const paths: string[] = [];
+  for (const input of inputs) {
+    const resolvedPaths = resolveSourceFilePaths(input, resolvers);
+    // Falling back to the literal input would quietly succeed whenever it happens to be a valid
+    // TypeScript file, declaring a build the bundler refuses to produce.
+    if (!resolvedPaths) return { paths: undefined, unresolvedInput: input };
+
+    paths.push(...resolvedPaths);
+  }
+  return { paths: [...new Set(paths)], unresolvedInput: undefined };
+}
+
+function reportUnresolvedInput(input: string): void {
+  console.error(`Failed to resolve the input for declaration generation: ${input}`);
 }
 
 function getInputFiles(input: RolldownOptions['input']): string[] {

--- a/src/commands/build/build.ts
+++ b/src/commands/build/build.ts
@@ -127,6 +127,9 @@ export async function build(argv: ArgumentsType<AnyBuilderType>, targetCategory:
   // The bundler resolves per output format, so declarations must cover every platform in play.
   const platforms = outputOptionsList.map((opts): BundlerPlatform => (opts.format === 'commonjs' ? 'node' : 'browser'));
   const declarationInputs = resolveDeclarationInputs(argv, inputs, platforms);
+  // Explicit inputs that the bundler ignores on every platform leave nothing to declare. Generating
+  // anyway would emit declarations for every file under src/, since an empty entry list is no filter.
+  const hasNothingToDeclare = declarationInputs?.length === 0;
 
   process.chdir(packageDirPath);
   await fs.promises.rm(outDirPath, { recursive: true, force: true });
@@ -143,7 +146,7 @@ export async function build(argv: ArgumentsType<AnyBuilderType>, targetCategory:
         )
       );
     }
-    if (!(await generateDeclarationFiles(argv, packageDirPath, outDirPath, declarationInputs))) {
+    if (!hasNothingToDeclare && !(await generateDeclarationFiles(argv, packageDirPath, outDirPath, declarationInputs))) {
       process.exit(1);
     }
     return;
@@ -221,6 +224,7 @@ export async function build(argv: ArgumentsType<AnyBuilderType>, targetCategory:
     if (
       targetDetail !== 'app-node' &&
       targetDetail !== 'functions' &&
+      !hasNothingToDeclare &&
       !(await generateDeclarationFiles(argv, packageDirPath, outDirPath, declarationInputs))
     ) {
       process.exit(1);
@@ -300,12 +304,10 @@ function watchRolldown(
             // The bundler re-resolves its literal inputs on every rebuild, so the declaration inputs
             // are resolved again here; reusing the initial list would describe the previous sources
             // after an entry (e.g. a package entry field) started resolving elsewhere.
-            await generateDeclarationFiles(
-              argv,
-              packageDirPath,
-              outDirPath,
-              resolveDeclarationInputs(argv, inputs, platforms)
-            );
+            const rebuiltInputs = resolveDeclarationInputs(argv, inputs, platforms);
+            if (rebuiltInputs?.length !== 0) {
+              await generateDeclarationFiles(argv, packageDirPath, outDirPath, rebuiltInputs);
+            }
           }
           break;
         }
@@ -439,11 +441,9 @@ function resolveDeclarationInputs(
   const resolvers = createBundlerResolvers(platforms);
   return [
     ...new Set(
-      inputs.flatMap((input) => {
-        const resolvedPaths = resolveSourceFilePaths(input, resolvers);
-        // An unresolvable path is kept as is to let the compiler report it.
-        return resolvedPaths.length > 0 ? resolvedPaths : [input];
-      })
+      // An unresolvable path is kept as is to let the compiler report it, whereas a path the bundler
+      // deliberately ignores contributes nothing.
+      inputs.flatMap((input) => resolveSourceFilePaths(input, resolvers) ?? [input])
     ),
   ];
 }

--- a/src/commands/build/build.ts
+++ b/src/commands/build/build.ts
@@ -87,14 +87,7 @@ export async function build(argv: ArgumentsType<AnyBuilderType>, targetCategory:
   const inputs = verifyInput(argv, cwd, packageDirPath);
   const targetDetail = detectTargetDetail(targetCategory, inputs, packageDirPath);
   const outDirPath = resolveOutDirPath(argv, cwd, packageDirPath, inputs, targetCategory);
-  // Restrict declaration files to the entry files (and their imports) only when inputs are explicit,
-  // to keep the default behavior of emitting declarations for all files under src/. tsc cannot take a
-  // bundler-style entry (a directory, or a ".js" specifier aliased to a ".ts" source) literally, so
-  // each one is resolved to the source file it refers to; an unresolvable path is kept as is to let
-  // the compiler report it.
-  const declarationInputs = argv.input?.length
-    ? [...new Set(inputs.map((input) => resolveSourceFilePath(input) ?? input))]
-    : undefined;
+  const declarationInputs = resolveDeclarationInputs(argv, inputs);
 
   if (verbose) {
     console.info('argv:', argv);
@@ -190,7 +183,7 @@ export async function build(argv: ArgumentsType<AnyBuilderType>, targetCategory:
       targetDetail,
       packageDirPath,
       outDirPath,
-      declarationInputs,
+      inputs,
       options,
       outputOptionsList,
       pathToRelativePath,
@@ -249,7 +242,7 @@ function watchRolldown(
   targetDetail: string,
   packageDirPath: string,
   outDirPath: string,
-  declarationInputs: string[] | undefined,
+  inputs: string[],
   options: RolldownOptions,
   outputOptionsList: OutputOptions[],
   pathToRelativePath: (paths: string | Readonly<string[]>) => string[],
@@ -304,7 +297,10 @@ function watchRolldown(
           }
 
           if (targetDetail !== 'app-node' && targetDetail !== 'functions') {
-            await generateDeclarationFiles(argv, packageDirPath, outDirPath, declarationInputs);
+            // The bundler re-resolves its literal inputs on every rebuild, so the declaration inputs
+            // are resolved again here; reusing the initial list would describe the previous sources
+            // after an entry (e.g. a package entry field) started resolving elsewhere.
+            await generateDeclarationFiles(argv, packageDirPath, outDirPath, resolveDeclarationInputs(argv, inputs));
           }
           break;
         }
@@ -420,6 +416,19 @@ function createFunctionsInputEntries(inputs: string[]): Record<string, string> {
     entries[name] = input;
   }
   return entries;
+}
+
+// Restricts declaration files to the entry files (and their imports) only when inputs are explicit,
+// to keep the default behavior of emitting declarations for all files under src/. tsc cannot take a
+// bundler-style entry (a directory, or a ".js" specifier aliased to a ".ts" source) literally, so each
+// one is resolved to the source file it refers to; an unresolvable path is kept as is to let the
+// compiler report it. Resolution depends on the file system, so a watch rebuild has to redo it.
+function resolveDeclarationInputs(
+  argv: ArgumentsType<AnyBuilderType>,
+  inputs: string[]
+): string[] | undefined {
+  if (!argv.input?.length) return undefined;
+  return [...new Set(inputs.map((input) => resolveSourceFilePath(input) ?? input))];
 }
 
 function getInputFiles(input: RolldownOptions['input']): string[] {

--- a/src/commands/build/inputResolver.ts
+++ b/src/commands/build/inputResolver.ts
@@ -21,18 +21,26 @@ export const bundlerResolveOptions = {
 // Verified against the bundler: a directory whose package.json has "browser", "module" and "main"
 // resolves to the browser entry for an ESM output and to the main entry for a CommonJS one, and the
 // "browser" alias map only takes effect for the former.
-const platformResolveOptions: Record<BundlerPlatform, { aliasFields: string[][]; mainFields: string[] }> = {
-  browser: { aliasFields: [['browser']], mainFields: ['browser', 'module', 'main'] },
-  node: { aliasFields: [], mainFields: ['main', 'module'] },
+const platformResolveOptions: Record<
+  BundlerPlatform,
+  { aliasFields: string[][]; conditionNames: string[]; mainFields: string[] }
+> = {
+  browser: {
+    aliasFields: [['browser']],
+    conditionNames: ['import', 'browser', 'default'],
+    mainFields: ['browser', 'module', 'main'],
+  },
+  node: { aliasFields: [], conditionNames: ['import', 'node', 'default'], mainFields: ['main', 'module'] },
 };
 
-// The resolver reports a deliberately ignored entry as an error rather than as a distinct state, so
-// the two have to be told apart by this prefix.
 const ignoredPathErrorPrefix = 'Path is ignored';
 
-/** Reports whether the bundler can resolve the path on any platform, for validating an input. */
+/** Reports whether any platform accepts the path, which is all an input needs to be worth passing on. */
 export function isBundlerResolvablePath(literalPath: string): boolean {
-  return resolveSourceFilePaths(literalPath, createBundlerResolvers(['browser', 'node'])) !== undefined;
+  return createBundlerResolvers(['browser', 'node']).some((resolver) => {
+    const { error, path: resolvedPath } = resolve(literalPath, resolver);
+    return resolvedPath !== undefined || isIgnored(error);
+  });
 }
 
 /**
@@ -40,21 +48,30 @@ export function isBundlerResolvablePath(literalPath: string): boolean {
  * the outputs resolve differently per platform (e.g. a "browser" entry for ESM and a "main" entry for
  * CommonJS). An empty array means the bundler deliberately ignores the entry on every platform (a
  * `"browser"` mapping to `false`), which is a successful resolution that simply has no source file.
- * Returns undefined only when the bundler cannot resolve the path either.
+ * Returns undefined when any requested platform fails to resolve, since the bundler fails there too.
  */
 export function resolveSourceFilePaths(literalPath: string, resolvers: ResolverFactory[]): string[] | undefined {
   const resolvedPaths: string[] = [];
-  let isUnresolved = false;
   for (const resolver of resolvers) {
-    const { error, path: resolvedPath } = resolver.sync(path.dirname(literalPath), `./${path.basename(literalPath)}`);
+    const { error, path: resolvedPath } = resolve(literalPath, resolver);
     if (resolvedPath) {
       resolvedPaths.push(resolvedPath);
-    } else if (!error?.startsWith(ignoredPathErrorPrefix)) {
-      isUnresolved = true;
+    } else if (!isIgnored(error)) {
+      // Succeeding here would let declaration generation pass for a build the bundler rejects.
+      return undefined;
     }
   }
-  // A path resolved for one platform still needs its declarations, even if another platform fails.
-  return isUnresolved && resolvedPaths.length === 0 ? undefined : [...new Set(resolvedPaths)];
+  return [...new Set(resolvedPaths)];
+}
+
+function resolve(literalPath: string, resolver: ResolverFactory): { error?: string; path?: string } {
+  return resolver.sync(path.dirname(literalPath), `./${path.basename(literalPath)}`);
+}
+
+// A deliberately ignored entry is reported as an error rather than as a distinct state, so the two
+// have to be told apart by the message itself.
+function isIgnored(error: string | undefined): boolean {
+  return error?.startsWith(ignoredPathErrorPrefix) ?? false;
 }
 
 /**

--- a/src/commands/build/inputResolver.ts
+++ b/src/commands/build/inputResolver.ts
@@ -3,23 +3,51 @@ import path from 'node:path';
 
 // The single source of truth for the bundler's `resolve` configuration, so that the entry paths the
 // bundler accepts and the ones resolved for declaration generation can never drift apart.
+// `mainFields` and `mainFiles` are pinned to the bundler's own defaults rather than left implicit,
+// since directory resolution below has to reproduce their precedence exactly.
 export const bundlerExtensionAlias: Record<string, string[]> = {
   '.cjs': ['.cjs', '.cts'],
   '.js': ['.js', '.ts', '.tsx'],
   '.mjs': ['.mjs', '.mts'],
 };
 export const bundlerExtensions = ['.cts', '.mts', '.ts', '.tsx', '.cjs', '.mjs', '.js', '.jsx', '.json'];
+export const bundlerMainFields = ['module', 'main'];
+export const bundlerMainFiles = ['index'];
 
 /**
  * Resolves a bundler-style entry path to the source file the bundler loads for it: a directory
- * resolves through its `index` file, a `.js` specifier falls back to its aliased `.ts` source, and an
- * extension-less path gains one of the configured extensions. Returns undefined when no file exists.
+ * resolves through its package entry fields or its `index` file, a `.js` specifier falls back to its
+ * aliased `.ts` source, and an extension-less path gains one of the configured extensions.
+ * Returns undefined when no file exists.
  */
-export function resolveSourceFilePath(literalPath: string): string | undefined {
+export function resolveSourceFilePath(literalPath: string, visitedDirPaths?: Set<string>): string | undefined {
   const stats = fs.statSync(literalPath, { throwIfNoEntry: false });
   if (stats?.isFile()) return literalPath;
+  if (stats?.isDirectory()) return resolveDirectoryPath(literalPath, visitedDirPaths ?? new Set());
+  return resolveWithExtensions(literalPath);
+}
 
-  const basePath = stats?.isDirectory() ? path.join(literalPath, 'index') : literalPath;
+function resolveDirectoryPath(dirPath: string, visitedDirPaths: Set<string>): string | undefined {
+  // A package entry field may point back at an ancestor directory, which would otherwise recurse forever.
+  if (visitedDirPaths.has(dirPath)) return undefined;
+  visitedDirPaths.add(dirPath);
+
+  const packageJson = readPackageJson(path.join(dirPath, 'package.json'));
+  for (const field of bundlerMainFields) {
+    const entry = packageJson?.[field];
+    // The entry itself may be extension-aliased or another directory, so it is resolved recursively.
+    const resolvedPath =
+      typeof entry === 'string' ? resolveSourceFilePath(path.resolve(dirPath, entry), visitedDirPaths) : undefined;
+    if (resolvedPath) return resolvedPath;
+  }
+  for (const mainFile of bundlerMainFiles) {
+    const resolvedPath = resolveWithExtensions(path.join(dirPath, mainFile));
+    if (resolvedPath) return resolvedPath;
+  }
+  return undefined;
+}
+
+function resolveWithExtensions(basePath: string): string | undefined {
   const extension = path.extname(basePath);
   const candidates = [
     // An aliased extension takes precedence, since the bundler swaps it instead of appending to it.
@@ -27,4 +55,15 @@ export function resolveSourceFilePath(literalPath: string): string | undefined {
     ...bundlerExtensions.map((ext) => basePath + ext),
   ];
   return candidates.find((candidate) => fs.statSync(candidate, { throwIfNoEntry: false })?.isFile());
+}
+
+// A malformed or unreadable package.json is ignored so that resolution falls back to the main files,
+// matching the bundler, which likewise does not fail the build over it.
+function readPackageJson(packageJsonPath: string): Record<string, unknown> | undefined {
+  try {
+    const parsed: unknown = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+    return typeof parsed === 'object' && parsed !== null ? (parsed as Record<string, unknown>) : undefined;
+  } catch {
+    return undefined;
+  }
 }

--- a/src/commands/build/inputResolver.ts
+++ b/src/commands/build/inputResolver.ts
@@ -1,0 +1,30 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+// The single source of truth for the bundler's `resolve` configuration, so that the entry paths the
+// bundler accepts and the ones resolved for declaration generation can never drift apart.
+export const bundlerExtensionAlias: Record<string, string[]> = {
+  '.cjs': ['.cjs', '.cts'],
+  '.js': ['.js', '.ts', '.tsx'],
+  '.mjs': ['.mjs', '.mts'],
+};
+export const bundlerExtensions = ['.cts', '.mts', '.ts', '.tsx', '.cjs', '.mjs', '.js', '.jsx', '.json'];
+
+/**
+ * Resolves a bundler-style entry path to the source file the bundler loads for it: a directory
+ * resolves through its `index` file, a `.js` specifier falls back to its aliased `.ts` source, and an
+ * extension-less path gains one of the configured extensions. Returns undefined when no file exists.
+ */
+export function resolveSourceFilePath(literalPath: string): string | undefined {
+  const stats = fs.statSync(literalPath, { throwIfNoEntry: false });
+  if (stats?.isFile()) return literalPath;
+
+  const basePath = stats?.isDirectory() ? path.join(literalPath, 'index') : literalPath;
+  const extension = path.extname(basePath);
+  const candidates = [
+    // An aliased extension takes precedence, since the bundler swaps it instead of appending to it.
+    ...(bundlerExtensionAlias[extension] ?? []).map((ext) => basePath.slice(0, -extension.length) + ext),
+    ...bundlerExtensions.map((ext) => basePath + ext),
+  ];
+  return candidates.find((candidate) => fs.statSync(candidate, { throwIfNoEntry: false })?.isFile());
+}

--- a/src/commands/build/inputResolver.ts
+++ b/src/commands/build/inputResolver.ts
@@ -26,21 +26,35 @@ const platformResolveOptions: Record<BundlerPlatform, { aliasFields: string[][];
   node: { aliasFields: [], mainFields: ['main', 'module'] },
 };
 
+// The resolver reports a deliberately ignored entry as an error rather than as a distinct state, so
+// the two have to be told apart by this prefix.
+const ignoredPathErrorPrefix = 'Path is ignored';
+
 /** Reports whether the bundler can resolve the path on any platform, for validating an input. */
 export function isBundlerResolvablePath(literalPath: string): boolean {
-  return resolveSourceFilePaths(literalPath, createBundlerResolvers(['browser', 'node'])).length > 0;
+  return resolveSourceFilePaths(literalPath, createBundlerResolvers(['browser', 'node'])) !== undefined;
 }
 
 /**
  * Resolves an entry path to every source file the bundler loads for it, which is more than one when
  * the outputs resolve differently per platform (e.g. a "browser" entry for ESM and a "main" entry for
- * CommonJS). Returns an empty array when the bundler cannot resolve the path either.
+ * CommonJS). An empty array means the bundler deliberately ignores the entry on every platform (a
+ * `"browser"` mapping to `false`), which is a successful resolution that simply has no source file.
+ * Returns undefined only when the bundler cannot resolve the path either.
  */
-export function resolveSourceFilePaths(literalPath: string, resolvers: ResolverFactory[]): string[] {
-  const resolvedPaths = resolvers.map(
-    (resolver) => resolver.sync(path.dirname(literalPath), `./${path.basename(literalPath)}`).path
-  );
-  return [...new Set(resolvedPaths.filter((resolvedPath) => resolvedPath !== undefined))];
+export function resolveSourceFilePaths(literalPath: string, resolvers: ResolverFactory[]): string[] | undefined {
+  const resolvedPaths: string[] = [];
+  let isUnresolved = false;
+  for (const resolver of resolvers) {
+    const { error, path: resolvedPath } = resolver.sync(path.dirname(literalPath), `./${path.basename(literalPath)}`);
+    if (resolvedPath) {
+      resolvedPaths.push(resolvedPath);
+    } else if (!error?.startsWith(ignoredPathErrorPrefix)) {
+      isUnresolved = true;
+    }
+  }
+  // A path resolved for one platform still needs its declarations, even if another platform fails.
+  return isUnresolved && resolvedPaths.length === 0 ? undefined : [...new Set(resolvedPaths)];
 }
 
 /**

--- a/src/commands/build/inputResolver.ts
+++ b/src/commands/build/inputResolver.ts
@@ -1,109 +1,42 @@
-import fs from 'node:fs';
 import path from 'node:path';
 
-// The single source of truth for the bundler's `resolve` configuration, so that the entry paths the
-// bundler accepts and the ones resolved for declaration generation can never drift apart.
-// `mainFields` and `mainFiles` are pinned to the bundler's own defaults rather than left implicit,
-// since directory resolution below has to reproduce their precedence exactly.
-export const bundlerExtensionAlias: Record<string, string[]> = {
-  '.cjs': ['.cjs', '.cts'],
-  '.js': ['.js', '.ts', '.tsx'],
-  // The bundler substitutes TypeScript sources for a missing `.jsx` file even without this entry;
-  // spelling it out keeps declaration resolution from having to rediscover the same precedence.
-  '.jsx': ['.jsx', '.ts', '.tsx'],
-  '.mjs': ['.mjs', '.mts'],
+import { ResolverFactory } from 'rolldown/experimental';
+
+// The single source of truth for the bundler's `resolve` configuration: the same object configures
+// both the bundler and the resolver below, so the two cannot drift apart.
+export const bundlerResolveOptions = {
+  extensionAlias: {
+    '.cjs': ['.cjs', '.cts'],
+    '.js': ['.js', '.ts', '.tsx'],
+    '.jsx': ['.jsx', '.ts', '.tsx'],
+    '.mjs': ['.mjs', '.mts'],
+  },
+  extensions: ['.cts', '.mts', '.ts', '.tsx', '.cjs', '.mjs', '.js', '.jsx', '.json'],
+  mainFields: ['module', 'main'],
+  mainFiles: ['index'],
 };
-export const bundlerExtensions = ['.cts', '.mts', '.ts', '.tsx', '.cjs', '.mjs', '.js', '.jsx', '.json'];
-export const bundlerMainFields = ['module', 'main'];
-export const bundlerMainFiles = ['index'];
 
 /**
- * Resolves a bundler-style entry path to the source file the bundler loads for it: a `.js` specifier
- * falls back to its aliased `.ts` source, an extension-less path gains one of the configured
- * extensions, and a directory resolves through its package entry fields or its `index` file.
- * Returns undefined when no file exists.
+ * Creates a resolver for one resolution pass. Its cache never observes later file system changes, so
+ * a watch rebuild must create a new one rather than reuse an earlier resolver.
  */
-export function resolveSourceFilePath(literalPath: string, visitedDirPaths?: Set<string>): string | undefined {
-  const stats = fs.statSync(literalPath, { throwIfNoEntry: false });
-  if (stats?.isFile()) return literalPath;
-
-  // The configured extensions are tried before an existing directory is treated as a package, so that
-  // `src/entry.ts` wins over `src/entry/index.ts` exactly as it does in the bundler.
-  const resolvedPath = resolveWithExtensions(literalPath);
-  if (resolvedPath) return resolvedPath;
-
-  return stats?.isDirectory() ? resolveDirectoryPath(literalPath, visitedDirPaths ?? new Set()) : undefined;
+export function createBundlerResolver(): ResolverFactory {
+  return new ResolverFactory(bundlerResolveOptions);
 }
 
-function resolveDirectoryPath(dirPath: string, visitedDirPaths: Set<string>): string | undefined {
-  // A package entry field may point back at an ancestor directory, which would otherwise recurse
-  // forever. Symlinks make that cycle reachable through ever-growing lexical paths (`loop/loop/...`),
-  // so directories are identified by their canonical path.
-  const visitedKey = toCanonicalDirPath(dirPath);
-  if (visitedDirPaths.has(visitedKey)) return undefined;
-  visitedDirPaths.add(visitedKey);
-
-  const packageJson = readPackageJson(path.join(dirPath, 'package.json'));
-  for (const field of bundlerMainFields) {
-    const entry = packageJson?.[field];
-    if (typeof entry !== 'string') continue;
-
-    // An entry pointing back at an enclosing directory (directly or through a symlink) makes the
-    // bundler fall through to the main files rather than consider the remaining fields, so a later
-    // field must not win here.
-    const entryPath = path.resolve(dirPath, entry);
-    if (visitedDirPaths.has(toCanonicalDirPath(entryPath))) break;
-
-    // The entry itself may be extension-aliased or another directory, so it is resolved recursively.
-    const resolvedPath = resolveSourceFilePath(entryPath, visitedDirPaths);
-    if (resolvedPath) return resolvedPath;
-  }
-  for (const mainFile of bundlerMainFiles) {
-    const resolvedPath = resolveWithExtensions(path.join(dirPath, mainFile));
-    if (resolvedPath) return resolvedPath;
-  }
-  return undefined;
-}
-
-function toCanonicalDirPath(dirPath: string): string {
-  try {
-    return fs.realpathSync(dirPath);
-  } catch {
-    // An unresolvable path cannot form a cycle, so its lexical form is a sufficient identity.
-    return dirPath;
-  }
-}
-
-function resolveWithExtensions(basePath: string): string | undefined {
-  const extension = path.extname(basePath);
-  const candidates = [
-    // An aliased extension takes precedence, since the bundler swaps it instead of appending to it.
-    ...(bundlerExtensionAlias[extension] ?? []).map((ext) => basePath.slice(0, -extension.length) + ext),
-    ...bundlerExtensions.map((ext) => basePath + ext),
-  ];
-  return candidates.find((candidate) => fs.statSync(candidate, { throwIfNoEntry: false })?.isFile());
-}
-
-function readPackageJson(packageJsonPath: string): Record<string, unknown> | undefined {
-  let content: string;
-  try {
-    content = fs.readFileSync(packageJsonPath, 'utf8');
-  } catch (error) {
-    // Most directories simply have no package.json, which is not an error for the bundler either.
-    if ((error as NodeJS.ErrnoException).code === 'ENOENT' || (error as NodeJS.ErrnoException).code === 'ENOTDIR') {
-      return undefined;
-    }
-    throw error;
-  }
-
-  try {
-    // The bundler's parser tolerates a byte order mark, so falling back to `index` over one would
-    // silently describe a different source than the bundled JavaScript.
-    const parsed: unknown = JSON.parse(content.replace(/^\uFEFF/, ''));
-    return typeof parsed === 'object' && parsed !== null ? (parsed as Record<string, unknown>) : undefined;
-  } catch (error) {
-    // Falling back to `index` here would let `--declaration-only` succeed for an entry the bundler
-    // cannot resolve at all, so a malformed package.json fails the build instead.
-    throw new Error(`Failed to parse ${packageJsonPath}: ${(error as Error).message}`);
-  }
+/**
+ * Resolves a bundler-style entry path to the source file the bundler loads for it, so that a
+ * declaration is always generated for the file that ends up bundled. Returns undefined when the
+ * bundler cannot resolve the path either.
+ */
+export function resolveSourceFilePath(literalPath: string, resolver?: ResolverFactory): string | undefined {
+  // The bundler's own resolver is used rather than a reimplementation of it: directory and package
+  // entry resolution has many behaviors that are easy to get subtly wrong (entry field precedence,
+  // nested packages, duplicate keys, byte order marks, symlink cycles), and any difference silently
+  // describes a different source than the one bundled.
+  const { path: resolvedPath } = (resolver ?? createBundlerResolver()).sync(
+    path.dirname(literalPath),
+    `./${path.basename(literalPath)}`
+  );
+  return resolvedPath;
 }

--- a/src/commands/build/inputResolver.ts
+++ b/src/commands/build/inputResolver.ts
@@ -15,22 +15,30 @@ export const bundlerMainFields = ['module', 'main'];
 export const bundlerMainFiles = ['index'];
 
 /**
- * Resolves a bundler-style entry path to the source file the bundler loads for it: a directory
- * resolves through its package entry fields or its `index` file, a `.js` specifier falls back to its
- * aliased `.ts` source, and an extension-less path gains one of the configured extensions.
+ * Resolves a bundler-style entry path to the source file the bundler loads for it: a `.js` specifier
+ * falls back to its aliased `.ts` source, an extension-less path gains one of the configured
+ * extensions, and a directory resolves through its package entry fields or its `index` file.
  * Returns undefined when no file exists.
  */
 export function resolveSourceFilePath(literalPath: string, visitedDirPaths?: Set<string>): string | undefined {
   const stats = fs.statSync(literalPath, { throwIfNoEntry: false });
   if (stats?.isFile()) return literalPath;
-  if (stats?.isDirectory()) return resolveDirectoryPath(literalPath, visitedDirPaths ?? new Set());
-  return resolveWithExtensions(literalPath);
+
+  // The configured extensions are tried before an existing directory is treated as a package, so that
+  // `src/entry.ts` wins over `src/entry/index.ts` exactly as it does in the bundler.
+  const resolvedPath = resolveWithExtensions(literalPath);
+  if (resolvedPath) return resolvedPath;
+
+  return stats?.isDirectory() ? resolveDirectoryPath(literalPath, visitedDirPaths ?? new Set()) : undefined;
 }
 
 function resolveDirectoryPath(dirPath: string, visitedDirPaths: Set<string>): string | undefined {
-  // A package entry field may point back at an ancestor directory, which would otherwise recurse forever.
-  if (visitedDirPaths.has(dirPath)) return undefined;
-  visitedDirPaths.add(dirPath);
+  // A package entry field may point back at an ancestor directory, which would otherwise recurse
+  // forever. Symlinks make that cycle reachable through ever-growing lexical paths (`loop/loop/...`),
+  // so directories are identified by their canonical path.
+  const visitedKey = toCanonicalDirPath(dirPath);
+  if (visitedDirPaths.has(visitedKey)) return undefined;
+  visitedDirPaths.add(visitedKey);
 
   const packageJson = readPackageJson(path.join(dirPath, 'package.json'));
   for (const field of bundlerMainFields) {
@@ -47,6 +55,15 @@ function resolveDirectoryPath(dirPath: string, visitedDirPaths: Set<string>): st
   return undefined;
 }
 
+function toCanonicalDirPath(dirPath: string): string {
+  try {
+    return fs.realpathSync(dirPath);
+  } catch {
+    // An unresolvable path cannot form a cycle, so its lexical form is a sufficient identity.
+    return dirPath;
+  }
+}
+
 function resolveWithExtensions(basePath: string): string | undefined {
   const extension = path.extname(basePath);
   const candidates = [
@@ -57,13 +74,26 @@ function resolveWithExtensions(basePath: string): string | undefined {
   return candidates.find((candidate) => fs.statSync(candidate, { throwIfNoEntry: false })?.isFile());
 }
 
-// A malformed or unreadable package.json is ignored so that resolution falls back to the main files,
-// matching the bundler, which likewise does not fail the build over it.
 function readPackageJson(packageJsonPath: string): Record<string, unknown> | undefined {
+  let content: string;
   try {
-    const parsed: unknown = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+    content = fs.readFileSync(packageJsonPath, 'utf8');
+  } catch (error) {
+    // Most directories simply have no package.json, which is not an error for the bundler either.
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT' || (error as NodeJS.ErrnoException).code === 'ENOTDIR') {
+      return undefined;
+    }
+    throw error;
+  }
+
+  try {
+    // The bundler's parser tolerates a byte order mark, so falling back to `index` over one would
+    // silently describe a different source than the bundled JavaScript.
+    const parsed: unknown = JSON.parse(content.replace(/^\uFEFF/, ''));
     return typeof parsed === 'object' && parsed !== null ? (parsed as Record<string, unknown>) : undefined;
-  } catch {
-    return undefined;
+  } catch (error) {
+    // Falling back to `index` here would let `--declaration-only` succeed for an entry the bundler
+    // cannot resolve at all, so a malformed package.json fails the build instead.
+    throw new Error(`Failed to parse ${packageJsonPath}: ${(error as Error).message}`);
   }
 }

--- a/src/commands/build/inputResolver.ts
+++ b/src/commands/build/inputResolver.ts
@@ -2,8 +2,11 @@ import path from 'node:path';
 
 import { ResolverFactory } from 'rolldown/experimental';
 
-// The single source of truth for the bundler's `resolve` configuration: the same object configures
-// both the bundler and the resolver below, so the two cannot drift apart.
+/** The platform the bundler resolves for, which it derives from each output format. */
+export type BundlerPlatform = 'browser' | 'node';
+
+// Only the options the bundler is actually given: its remaining defaults are platform-dependent, so
+// pinning them here would change which source gets bundled.
 export const bundlerResolveOptions = {
   extensionAlias: {
     '.cjs': ['.cjs', '.cts'],
@@ -12,31 +15,45 @@ export const bundlerResolveOptions = {
     '.mjs': ['.mjs', '.mts'],
   },
   extensions: ['.cts', '.mts', '.ts', '.tsx', '.cjs', '.mjs', '.js', '.jsx', '.json'],
-  mainFields: ['module', 'main'],
-  mainFiles: ['index'],
 };
 
-/**
- * Creates a resolver for one resolution pass. Its cache never observes later file system changes, so
- * a watch rebuild must create a new one rather than reuse an earlier resolver.
- */
-export function createBundlerResolver(): ResolverFactory {
-  return new ResolverFactory(bundlerResolveOptions);
+// The bundler's defaults for each platform, which `ResolverFactory` does not apply on its own.
+// Verified against the bundler: a directory whose package.json has "browser", "module" and "main"
+// resolves to the browser entry for an ESM output and to the main entry for a CommonJS one, and the
+// "browser" alias map only takes effect for the former.
+const platformResolveOptions: Record<BundlerPlatform, { aliasFields: string[][]; mainFields: string[] }> = {
+  browser: { aliasFields: [['browser']], mainFields: ['browser', 'module', 'main'] },
+  node: { aliasFields: [], mainFields: ['main', 'module'] },
+};
+
+/** Reports whether the bundler can resolve the path on any platform, for validating an input. */
+export function isBundlerResolvablePath(literalPath: string): boolean {
+  return resolveSourceFilePaths(literalPath, createBundlerResolvers(['browser', 'node'])).length > 0;
 }
 
 /**
- * Resolves a bundler-style entry path to the source file the bundler loads for it, so that a
- * declaration is always generated for the file that ends up bundled. Returns undefined when the
- * bundler cannot resolve the path either.
+ * Resolves an entry path to every source file the bundler loads for it, which is more than one when
+ * the outputs resolve differently per platform (e.g. a "browser" entry for ESM and a "main" entry for
+ * CommonJS). Returns an empty array when the bundler cannot resolve the path either.
  */
-export function resolveSourceFilePath(literalPath: string, resolver?: ResolverFactory): string | undefined {
+export function resolveSourceFilePaths(literalPath: string, resolvers: ResolverFactory[]): string[] {
+  const resolvedPaths = resolvers.map(
+    (resolver) => resolver.sync(path.dirname(literalPath), `./${path.basename(literalPath)}`).path
+  );
+  return [...new Set(resolvedPaths.filter((resolvedPath) => resolvedPath !== undefined))];
+}
+
+/**
+ * Creates the resolvers for one resolution pass. Their caches never observe later file system
+ * changes, so a watch rebuild must create new ones rather than reuse earlier resolvers.
+ */
+export function createBundlerResolvers(platforms: Iterable<BundlerPlatform>): ResolverFactory[] {
   // The bundler's own resolver is used rather than a reimplementation of it: directory and package
   // entry resolution has many behaviors that are easy to get subtly wrong (entry field precedence,
   // nested packages, duplicate keys, byte order marks, symlink cycles), and any difference silently
   // describes a different source than the one bundled.
-  const { path: resolvedPath } = (resolver ?? createBundlerResolver()).sync(
-    path.dirname(literalPath),
-    `./${path.basename(literalPath)}`
+  return [...new Set(platforms)].map(
+    (platform) =>
+      new ResolverFactory({ ...bundlerResolveOptions, ...platformResolveOptions[platform], mainFiles: ['index'] })
   );
-  return resolvedPath;
 }

--- a/src/commands/build/inputResolver.ts
+++ b/src/commands/build/inputResolver.ts
@@ -8,6 +8,9 @@ import path from 'node:path';
 export const bundlerExtensionAlias: Record<string, string[]> = {
   '.cjs': ['.cjs', '.cts'],
   '.js': ['.js', '.ts', '.tsx'],
+  // The bundler substitutes TypeScript sources for a missing `.jsx` file even without this entry;
+  // spelling it out keeps declaration resolution from having to rediscover the same precedence.
+  '.jsx': ['.jsx', '.ts', '.tsx'],
   '.mjs': ['.mjs', '.mts'],
 };
 export const bundlerExtensions = ['.cts', '.mts', '.ts', '.tsx', '.cjs', '.mjs', '.js', '.jsx', '.json'];
@@ -43,9 +46,16 @@ function resolveDirectoryPath(dirPath: string, visitedDirPaths: Set<string>): st
   const packageJson = readPackageJson(path.join(dirPath, 'package.json'));
   for (const field of bundlerMainFields) {
     const entry = packageJson?.[field];
+    if (typeof entry !== 'string') continue;
+
+    // An entry pointing back at an enclosing directory (directly or through a symlink) makes the
+    // bundler fall through to the main files rather than consider the remaining fields, so a later
+    // field must not win here.
+    const entryPath = path.resolve(dirPath, entry);
+    if (visitedDirPaths.has(toCanonicalDirPath(entryPath))) break;
+
     // The entry itself may be extension-aliased or another directory, so it is resolved recursively.
-    const resolvedPath =
-      typeof entry === 'string' ? resolveSourceFilePath(path.resolve(dirPath, entry), visitedDirPaths) : undefined;
+    const resolvedPath = resolveSourceFilePath(entryPath, visitedDirPaths);
     if (resolvedPath) return resolvedPath;
   }
   for (const mainFile of bundlerMainFiles) {

--- a/test/build.test.ts
+++ b/test/build.test.ts
@@ -2024,6 +2024,78 @@ export const routes = { helper };
     // Both emitted sources need declarations, since each output resolved to a different one.
     await expectFileExists(`${outDirPath}/dir/browser.d.ts`);
     await expectFileExists(`${outDirPath}/dir/main.d.ts`);
+
+    // Conditional exports are selected with the platform's condition names, so the declaration must
+    // describe the same condition's target as the bundled JavaScript.
+    await fs.promises.mkdir(`${fixtureDirPath}/src/cond/node_modules/dep`, { recursive: true });
+    await fs.promises.writeFile(
+      `${fixtureDirPath}/src/cond/package.json`,
+      JSON.stringify({ browser: { './main.ts': 'dep' }, main: './main.ts' })
+    );
+    await fs.promises.writeFile(`${fixtureDirPath}/src/cond/main.ts`, 'export const v = "main";\n');
+    await fs.promises.writeFile(
+      `${fixtureDirPath}/src/cond/node_modules/dep/package.json`,
+      JSON.stringify({ name: 'dep', exports: { browser: './browser.ts', default: './default.ts' } })
+    );
+    await fs.promises.writeFile(
+      `${fixtureDirPath}/src/cond/node_modules/dep/browser.ts`,
+      'export const v = "dep-browser";\n'
+    );
+    await fs.promises.writeFile(
+      `${fixtureDirPath}/src/cond/node_modules/dep/default.ts`,
+      'export const v = "dep-default";\n'
+    );
+    const conditionOutDirPath = '.tmp/test-fixtures/lib-platform-input-condition';
+    await buildWithPackagePath(
+      fixtureDirPath,
+      'lib',
+      '--module-type',
+      'esm',
+      '--input',
+      `${fixtureDirPath}/src/cond`,
+      '--out-dir',
+      conditionOutDirPath
+    );
+    await expectFileExists(`${conditionOutDirPath}/cond/node_modules/dep/browser.d.ts`);
+    expect(fs.existsSync(`${conditionOutDirPath}/cond/node_modules/dep/default.d.ts`)).toBe(false);
+  });
+
+  it('lib fails when an entry is unresolvable on any output platform', async () => {
+    const fixtureDirPath = '.tmp/test-fixtures/lib-platform-failure';
+    await fs.promises.rm(fixtureDirPath, { recursive: true, force: true });
+    await fs.promises.mkdir(`${fixtureDirPath}/src/dir`, { recursive: true });
+    await fs.promises.writeFile(
+      `${fixtureDirPath}/package.json`,
+      JSON.stringify({ type: 'module', packageManager: 'yarn@4.17.0' })
+    );
+    await fs.promises.writeFile(`${fixtureDirPath}/yarn.lock`, '');
+    await fs.promises.writeFile(
+      `${fixtureDirPath}/tsconfig.json`,
+      JSON.stringify({
+        compilerOptions: { module: 'esnext', moduleResolution: 'bundler', strict: true, target: 'es2022' },
+        include: ['src/**/*'],
+      })
+    );
+    // Resolvable for the CommonJS output but not the ESM one, which the bundler rejects outright, so
+    // succeeding on the resolvable platform alone would declare a build that cannot be produced.
+    await fs.promises.writeFile(
+      `${fixtureDirPath}/src/dir/package.json`,
+      JSON.stringify({ browser: { './main.ts': './missing.ts' }, main: './main.ts' })
+    );
+    await fs.promises.writeFile(`${fixtureDirPath}/src/dir/main.ts`, 'export const v = "main";\n');
+
+    const ret = await buildWithPackagePathAndGetStatus(
+      fixtureDirPath,
+      'lib',
+      '--declaration-only',
+      '--module-type',
+      'both',
+      '--input',
+      `${fixtureDirPath}/src/dir`,
+      '--out-dir',
+      '.tmp/test-fixtures/lib-platform-failure-out'
+    );
+    expect(ret.status).not.toBe(0);
   });
 
   it('lib skips declarations for entries the bundler ignores', async () => {

--- a/test/build.test.ts
+++ b/test/build.test.ts
@@ -1807,9 +1807,13 @@ export const routes = { helper };
     );
     expect(fs.readdirSync(`${packageEntryOutDirPath}/folder`)).toEqual(['entry.d.ts']);
 
-    // An unusable entry field falls back to "index" instead of failing, as the bundler does.
-    await fs.promises.writeFile(`${fixtureDirPath}/src/folder/package.json`, '{ "main": ');
-    const brokenEntryOutDirPath = '.tmp/test-fixtures/lib-resolved-input-broken-entry';
+    // A byte order mark must not hide the entry field: the bundler's parser accepts one, so falling
+    // back to "index" would emit declarations for a different source than the bundled JavaScript.
+    await fs.promises.writeFile(
+      `${fixtureDirPath}/src/folder/package.json`,
+      `\uFEFF${JSON.stringify({ main: './entry.ts' })}`
+    );
+    const bomEntryOutDirPath = '.tmp/test-fixtures/lib-resolved-input-bom-entry';
     await buildWithPackagePath(
       fixtureDirPath,
       'lib',
@@ -1817,9 +1821,76 @@ export const routes = { helper };
       '--input',
       `${fixtureDirPath}/src/folder`,
       '--out-dir',
-      brokenEntryOutDirPath
+      bomEntryOutDirPath
     );
-    await expectFileExists(`${brokenEntryOutDirPath}/folder/index.d.ts`);
+    expect(fs.readdirSync(`${bomEntryOutDirPath}/folder`)).toEqual(['entry.d.ts']);
+
+    // A package entry pointing back at its own directory through a symlink must not recurse forever.
+    await fs.promises.writeFile(`${fixtureDirPath}/src/folder/package.json`, JSON.stringify({ main: './loop' }));
+    await fs.promises.symlink('.', `${fixtureDirPath}/src/folder/loop`);
+    const cyclicEntryOutDirPath = '.tmp/test-fixtures/lib-resolved-input-cyclic-entry';
+    await buildWithPackagePath(
+      fixtureDirPath,
+      'lib',
+      '--declaration-only',
+      '--input',
+      `${fixtureDirPath}/src/folder`,
+      '--out-dir',
+      cyclicEntryOutDirPath
+    );
+    await expectFileExists(`${cyclicEntryOutDirPath}/folder/index.d.ts`);
+    await fs.promises.rm(`${fixtureDirPath}/src/folder/loop`);
+
+    // A malformed package.json must fail rather than fall back to "index": the bundler cannot resolve
+    // such an entry either, so succeeding here would emit declarations for an unbundlable entry.
+    await fs.promises.writeFile(`${fixtureDirPath}/src/folder/package.json`, '{ "main": ');
+    const brokenEntryRet = await buildWithPackagePathAndGetStatus(
+      fixtureDirPath,
+      'lib',
+      '--declaration-only',
+      '--input',
+      `${fixtureDirPath}/src/folder`,
+      '--out-dir',
+      '.tmp/test-fixtures/lib-resolved-input-broken-entry'
+    );
+    expect(brokenEntryRet.status).not.toBe(0);
+  });
+
+  it('lib resolves an entry file before an equally named directory', async () => {
+    const fixtureDirPath = '.tmp/test-fixtures/lib-sibling-input';
+    await fs.promises.rm(fixtureDirPath, { recursive: true, force: true });
+    await fs.promises.mkdir(`${fixtureDirPath}/src/entry`, { recursive: true });
+    await fs.promises.writeFile(
+      `${fixtureDirPath}/package.json`,
+      JSON.stringify({ type: 'module', packageManager: 'yarn@4.17.0' })
+    );
+    await fs.promises.writeFile(`${fixtureDirPath}/yarn.lock`, '');
+    await fs.promises.writeFile(
+      `${fixtureDirPath}/tsconfig.json`,
+      JSON.stringify({
+        compilerOptions: { module: 'esnext', moduleResolution: 'bundler', strict: true, target: 'es2022' },
+        include: ['src/**/*'],
+      })
+    );
+    // The bundler prefers "src/entry.ts" over "src/entry/index.ts", so the declarations must too.
+    await fs.promises.writeFile(`${fixtureDirPath}/src/entry.ts`, 'export const selected = "sibling";\n');
+    await fs.promises.writeFile(`${fixtureDirPath}/src/entry/index.ts`, 'export const selected = "directory";\n');
+
+    const outDirPath = '.tmp/test-fixtures/lib-sibling-input-out';
+    await buildWithPackagePath(
+      fixtureDirPath,
+      'lib',
+      '--module-type',
+      'esm',
+      '--input',
+      `${fixtureDirPath}/src/entry`,
+      '--out-dir',
+      outDirPath
+    );
+    // The bundled JavaScript and its declarations must describe the same source file.
+    expect(await fs.promises.readFile(`${outDirPath}/entry.js`, 'utf8')).toContain('sibling');
+    await expectFileExists(`${outDirPath}/entry.d.ts`);
+    expect(fs.existsSync(`${outDirPath}/entry/index.d.ts`)).toBe(false);
   });
 
   it('functions fails on conflicting entry names instead of silently dropping one', async () => {

--- a/test/build.test.ts
+++ b/test/build.test.ts
@@ -1825,6 +1825,47 @@ export const routes = { helper };
     );
     expect(fs.readdirSync(`${bomEntryOutDirPath}/folder`)).toEqual(['entry.d.ts']);
 
+    // A package entry field reaching another package directory does NOT honor that package's own
+    // entry fields; resolution falls through to its main files instead.
+    await fs.promises.mkdir(`${fixtureDirPath}/src/folder/nested`, { recursive: true });
+    await fs.promises.writeFile(`${fixtureDirPath}/src/folder/package.json`, JSON.stringify({ main: './nested' }));
+    await fs.promises.writeFile(
+      `${fixtureDirPath}/src/folder/nested/package.json`,
+      JSON.stringify({ main: './chosen.ts' })
+    );
+    await fs.promises.writeFile(`${fixtureDirPath}/src/folder/nested/chosen.ts`, 'export const chosen = 5;\n');
+    await fs.promises.writeFile(`${fixtureDirPath}/src/folder/nested/index.ts`, 'export const nested = 6;\n');
+    const nestedEntryOutDirPath = '.tmp/test-fixtures/lib-resolved-input-nested-entry';
+    await buildWithPackagePath(
+      fixtureDirPath,
+      'lib',
+      '--declaration-only',
+      '--input',
+      `${fixtureDirPath}/src/folder`,
+      '--out-dir',
+      nestedEntryOutDirPath
+    );
+    expect(fs.readdirSync(`${nestedEntryOutDirPath}/folder/nested`)).toEqual(['index.d.ts']);
+    await fs.promises.rm(`${fixtureDirPath}/src/folder/nested`, { recursive: true });
+
+    // Duplicate entry-field keys resolve to the first occurrence, unlike JSON.parse's last-wins.
+    await fs.promises.writeFile(
+      `${fixtureDirPath}/src/folder/package.json`,
+      '{ "main": "./entry.ts", "main": "./later.ts" }'
+    );
+    await fs.promises.writeFile(`${fixtureDirPath}/src/folder/later.ts`, 'export const fromLater: number = 7;\n');
+    const duplicateKeyOutDirPath = '.tmp/test-fixtures/lib-resolved-input-duplicate-key';
+    await buildWithPackagePath(
+      fixtureDirPath,
+      'lib',
+      '--declaration-only',
+      '--input',
+      `${fixtureDirPath}/src/folder`,
+      '--out-dir',
+      duplicateKeyOutDirPath
+    );
+    expect(fs.readdirSync(`${duplicateKeyOutDirPath}/folder`)).toEqual(['entry.d.ts']);
+
     // A package entry pointing back at its own directory through a symlink must not recurse forever.
     // The valid "main" here must NOT win: the bundler stops consulting later fields once one points
     // back at the directory, and falls through to "index" instead.

--- a/test/build.test.ts
+++ b/test/build.test.ts
@@ -1732,7 +1732,6 @@ export const routes = { helper };
     expect(fs.readdirSync(directoryOutDirPath)).toEqual(['schemas.d.ts']);
 
     // A directory entry whose name contains glob metacharacters still resolves to its index file.
-    // Declarations are not generated here because tsgo cannot take a directory as an entry.
     await fs.promises.mkdir(`${fixtureDirPath}/src/[b]racket`, { recursive: true });
     await fs.promises.writeFile(`${fixtureDirPath}/src/[b]racket/index.ts`, 'export const bracket = true;\n');
     const directoryEntryOutDirPath = '.tmp/test-fixtures/lib-glob-input-directory-entry';
@@ -1745,6 +1744,52 @@ export const routes = { helper };
       directoryEntryOutDirPath
     );
     await expectFileExists(`${directoryEntryOutDirPath}/index.js`);
+  });
+
+  it('lib generates declarations for directory and extension-aliased inputs', async () => {
+    const fixtureDirPath = '.tmp/test-fixtures/lib-resolved-input';
+    await fs.promises.rm(fixtureDirPath, { recursive: true, force: true });
+    await fs.promises.mkdir(`${fixtureDirPath}/src/folder`, { recursive: true });
+    await fs.promises.writeFile(
+      `${fixtureDirPath}/package.json`,
+      JSON.stringify({ type: 'module', packageManager: 'yarn@4.17.0' })
+    );
+    await fs.promises.writeFile(`${fixtureDirPath}/yarn.lock`, '');
+    await fs.promises.writeFile(
+      `${fixtureDirPath}/tsconfig.json`,
+      JSON.stringify({
+        compilerOptions: { module: 'esnext', moduleResolution: 'bundler', strict: true, target: 'es2022' },
+        include: ['src/**/*'],
+      })
+    );
+    await fs.promises.writeFile(`${fixtureDirPath}/src/index.ts`, 'export const fromIndex: number = 1;\n');
+    await fs.promises.writeFile(`${fixtureDirPath}/src/folder/index.ts`, 'export const fromFolder: number = 2;\n');
+
+    // A directory input, which the bundler resolves through its "index" file (was TS6231).
+    const directoryOutDirPath = '.tmp/test-fixtures/lib-resolved-input-directory';
+    await buildWithPackagePath(
+      fixtureDirPath,
+      'lib',
+      '--declaration-only',
+      '--input',
+      `${fixtureDirPath}/src/folder`,
+      '--out-dir',
+      directoryOutDirPath
+    );
+    await expectFileExists(`${directoryOutDirPath}/folder/index.d.ts`);
+
+    // A ".js" specifier aliased to its ".ts" source (was TS6504).
+    const aliasOutDirPath = '.tmp/test-fixtures/lib-resolved-input-alias';
+    await buildWithPackagePath(
+      fixtureDirPath,
+      'lib',
+      '--declaration-only',
+      '--input',
+      `${fixtureDirPath}/src/index.js`,
+      '--out-dir',
+      aliasOutDirPath
+    );
+    await expectFileExists(`${aliasOutDirPath}/index.d.ts`);
   });
 
   it('functions fails on conflicting entry names instead of silently dropping one', async () => {

--- a/test/build.test.ts
+++ b/test/build.test.ts
@@ -2026,6 +2026,63 @@ export const routes = { helper };
     await expectFileExists(`${outDirPath}/dir/main.d.ts`);
   });
 
+  it('lib skips declarations for entries the bundler ignores', async () => {
+    const fixtureDirPath = '.tmp/test-fixtures/lib-ignored-input';
+    await fs.promises.rm(fixtureDirPath, { recursive: true, force: true });
+    await fs.promises.mkdir(`${fixtureDirPath}/src/dir`, { recursive: true });
+    await fs.promises.writeFile(
+      `${fixtureDirPath}/package.json`,
+      JSON.stringify({ type: 'module', packageManager: 'yarn@4.17.0' })
+    );
+    await fs.promises.writeFile(`${fixtureDirPath}/yarn.lock`, '');
+    await fs.promises.writeFile(
+      `${fixtureDirPath}/tsconfig.json`,
+      JSON.stringify({
+        compilerOptions: { module: 'esnext', moduleResolution: 'bundler', strict: true, target: 'es2022' },
+        include: ['src/**/*'],
+      })
+    );
+    // A "browser" mapping to false makes the bundler ignore the entry rather than fail to resolve it.
+    await fs.promises.writeFile(
+      `${fixtureDirPath}/src/dir/package.json`,
+      JSON.stringify({ browser: { './main.ts': false }, main: './main.ts' })
+    );
+    await fs.promises.writeFile(`${fixtureDirPath}/src/dir/main.ts`, 'export const v = "main";\n');
+    await fs.promises.writeFile(`${fixtureDirPath}/src/unrelated.ts`, 'export const unrelated = 1;\n');
+
+    // Every platform ignores the entry, so there is nothing to declare. Emitting anyway would fall
+    // back to declaring every file under src/, including the unrelated one.
+    const ignoredOutDirPath = '.tmp/test-fixtures/lib-ignored-input-out';
+    await buildWithPackagePath(
+      fixtureDirPath,
+      'lib',
+      '--module-type',
+      'esm',
+      '--input',
+      `${fixtureDirPath}/src/dir`,
+      '--out-dir',
+      ignoredOutDirPath
+    );
+    const ignoredDeclarations = fs
+      .readdirSync(ignoredOutDirPath, { recursive: true })
+      .filter((name) => name.toString().endsWith('.d.ts'));
+    expect(ignoredDeclarations).toEqual([]);
+
+    // Only the browser platform ignores it, so the CommonJS output still needs its declaration.
+    const mixedOutDirPath = '.tmp/test-fixtures/lib-ignored-input-mixed';
+    await buildWithPackagePath(
+      fixtureDirPath,
+      'lib',
+      '--module-type',
+      'both',
+      '--input',
+      `${fixtureDirPath}/src/dir`,
+      '--out-dir',
+      mixedOutDirPath
+    );
+    await expectFileExists(`${mixedOutDirPath}/dir/main.d.ts`);
+  });
+
   it('functions fails on conflicting entry names instead of silently dropping one', async () => {
     const fixtureDirPath = '.tmp/test-fixtures/functions-conflicting-entries';
     await fs.promises.rm(fixtureDirPath, { recursive: true, force: true });

--- a/test/build.test.ts
+++ b/test/build.test.ts
@@ -1885,7 +1885,9 @@ export const routes = { helper };
       '--out-dir',
       cyclicEntryOutDirPath
     );
-    expect(fs.readdirSync(`${cyclicEntryOutDirPath}/folder`)).toEqual(['index.d.ts']);
+    // The two platforms select different entries here, and both are emitted: the ESM output follows
+    // "module" into the cycle and falls through to "index", while the CommonJS output takes "main".
+    expect(fs.readdirSync(`${cyclicEntryOutDirPath}/folder`).toSorted()).toEqual(['index.d.ts', 'later.d.ts']);
     await fs.promises.rm(`${fixtureDirPath}/src/folder/loop`);
 
     // A malformed package.json must fail rather than fall back to "index": the bundler cannot resolve
@@ -1978,6 +1980,50 @@ export const routes = { helper };
       expect(await fs.promises.readFile(`${outDirPath}/entry.js`, 'utf8')).toContain(marker);
       await expectFileExists(`${outDirPath}/entry.d.ts`);
     }
+  });
+
+  it('lib resolves package entry fields per output platform', async () => {
+    const fixtureDirPath = '.tmp/test-fixtures/lib-platform-input';
+    await fs.promises.rm(fixtureDirPath, { recursive: true, force: true });
+    await fs.promises.mkdir(`${fixtureDirPath}/src/dir`, { recursive: true });
+    await fs.promises.writeFile(
+      `${fixtureDirPath}/package.json`,
+      JSON.stringify({ type: 'module', packageManager: 'yarn@4.17.0' })
+    );
+    await fs.promises.writeFile(`${fixtureDirPath}/yarn.lock`, '');
+    await fs.promises.writeFile(
+      `${fixtureDirPath}/tsconfig.json`,
+      JSON.stringify({
+        compilerOptions: { module: 'esnext', moduleResolution: 'bundler', strict: true, target: 'es2022' },
+        include: ['src/**/*'],
+      })
+    );
+    await fs.promises.writeFile(
+      `${fixtureDirPath}/src/dir/package.json`,
+      JSON.stringify({ browser: './browser.ts', module: './module.ts', main: './main.ts' })
+    );
+    for (const name of ['browser', 'module', 'main']) {
+      await fs.promises.writeFile(`${fixtureDirPath}/src/dir/${name}.ts`, `export const v = "${name}";\n`);
+    }
+
+    // The bundler picks the "browser" entry for an ESM output and the "main" entry for a CommonJS
+    // one, so overriding `mainFields` for both would silently change which source ships.
+    const outDirPath = '.tmp/test-fixtures/lib-platform-input-out';
+    await buildWithPackagePath(
+      fixtureDirPath,
+      'lib',
+      '--module-type',
+      'both',
+      '--input',
+      `${fixtureDirPath}/src/dir`,
+      '--out-dir',
+      outDirPath
+    );
+    expect(await fs.promises.readFile(`${outDirPath}/dir/browser.js`, 'utf8')).toContain('browser');
+    expect(await fs.promises.readFile(`${outDirPath}/dir/main.cjs`, 'utf8')).toContain('main');
+    // Both emitted sources need declarations, since each output resolved to a different one.
+    await expectFileExists(`${outDirPath}/dir/browser.d.ts`);
+    await expectFileExists(`${outDirPath}/dir/main.d.ts`);
   });
 
   it('functions fails on conflicting entry names instead of silently dropping one', async () => {

--- a/test/build.test.ts
+++ b/test/build.test.ts
@@ -1826,7 +1826,13 @@ export const routes = { helper };
     expect(fs.readdirSync(`${bomEntryOutDirPath}/folder`)).toEqual(['entry.d.ts']);
 
     // A package entry pointing back at its own directory through a symlink must not recurse forever.
-    await fs.promises.writeFile(`${fixtureDirPath}/src/folder/package.json`, JSON.stringify({ main: './loop' }));
+    // The valid "main" here must NOT win: the bundler stops consulting later fields once one points
+    // back at the directory, and falls through to "index" instead.
+    await fs.promises.writeFile(
+      `${fixtureDirPath}/src/folder/package.json`,
+      JSON.stringify({ module: './loop', main: './later.ts' })
+    );
+    await fs.promises.writeFile(`${fixtureDirPath}/src/folder/later.ts`, 'export const fromLater: number = 4;\n');
     await fs.promises.symlink('.', `${fixtureDirPath}/src/folder/loop`);
     const cyclicEntryOutDirPath = '.tmp/test-fixtures/lib-resolved-input-cyclic-entry';
     await buildWithPackagePath(
@@ -1838,7 +1844,7 @@ export const routes = { helper };
       '--out-dir',
       cyclicEntryOutDirPath
     );
-    await expectFileExists(`${cyclicEntryOutDirPath}/folder/index.d.ts`);
+    expect(fs.readdirSync(`${cyclicEntryOutDirPath}/folder`)).toEqual(['index.d.ts']);
     await fs.promises.rm(`${fixtureDirPath}/src/folder/loop`);
 
     // A malformed package.json must fail rather than fall back to "index": the bundler cannot resolve
@@ -1891,6 +1897,46 @@ export const routes = { helper };
     expect(await fs.promises.readFile(`${outDirPath}/entry.js`, 'utf8')).toContain('sibling');
     await expectFileExists(`${outDirPath}/entry.d.ts`);
     expect(fs.existsSync(`${outDirPath}/entry/index.d.ts`)).toBe(false);
+  });
+
+  it('lib resolves a ".jsx" input to its TypeScript source', async () => {
+    for (const [extension, marker] of [
+      ['tsx', 'from-tsx'],
+      ['ts', 'from-ts'],
+    ]) {
+      const fixtureDirPath = `.tmp/test-fixtures/lib-jsx-input-${extension}`;
+      await fs.promises.rm(fixtureDirPath, { recursive: true, force: true });
+      await fs.promises.mkdir(`${fixtureDirPath}/src`, { recursive: true });
+      await fs.promises.writeFile(
+        `${fixtureDirPath}/package.json`,
+        JSON.stringify({ type: 'module', packageManager: 'yarn@4.17.0' })
+      );
+      await fs.promises.writeFile(`${fixtureDirPath}/yarn.lock`, '');
+      await fs.promises.writeFile(
+        `${fixtureDirPath}/tsconfig.json`,
+        JSON.stringify({
+          compilerOptions: { module: 'esnext', moduleResolution: 'bundler', strict: true, target: 'es2022' },
+          include: ['src/**/*'],
+        })
+      );
+      await fs.promises.writeFile(`${fixtureDirPath}/src/entry.${extension}`, `export const v = "${marker}";\n`);
+
+      // The bundler substitutes the TypeScript source for the missing ".jsx" file, so declaration
+      // generation must not receive the unresolved ".jsx" path (which fails with TS6504).
+      const outDirPath = `${fixtureDirPath}-out`;
+      await buildWithPackagePath(
+        fixtureDirPath,
+        'lib',
+        '--module-type',
+        'esm',
+        '--input',
+        `${fixtureDirPath}/src/entry.jsx`,
+        '--out-dir',
+        outDirPath
+      );
+      expect(await fs.promises.readFile(`${outDirPath}/entry.js`, 'utf8')).toContain(marker);
+      await expectFileExists(`${outDirPath}/entry.d.ts`);
+    }
   });
 
   it('functions fails on conflicting entry names instead of silently dropping one', async () => {

--- a/test/build.test.ts
+++ b/test/build.test.ts
@@ -2096,6 +2096,28 @@ export const routes = { helper };
       '.tmp/test-fixtures/lib-platform-failure-out'
     );
     expect(ret.status).not.toBe(0);
+
+    // The input names an existing TypeScript file that the browser platform cannot resolve. Falling
+    // back to the literal path would compile it happily, declaring a build the bundler refuses.
+    await fs.promises.writeFile(
+      `${fixtureDirPath}/src/package.json`,
+      JSON.stringify({ browser: { './index.ts': './missing.ts' } })
+    );
+    await fs.promises.writeFile(`${fixtureDirPath}/src/index.ts`, 'export const v = "index";\n');
+    const literalOutDirPath = '.tmp/test-fixtures/lib-platform-failure-literal';
+    const literalRet = await buildWithPackagePathAndGetStatus(
+      fixtureDirPath,
+      'lib',
+      '--declaration-only',
+      '--module-type',
+      'esm',
+      '--input',
+      `${fixtureDirPath}/src/index.ts`,
+      '--out-dir',
+      literalOutDirPath
+    );
+    expect(literalRet.status).not.toBe(0);
+    expect(fs.existsSync(`${literalOutDirPath}/index.d.ts`)).toBe(false);
   });
 
   it('lib skips declarations for entries the bundler ignores', async () => {

--- a/test/build.test.ts
+++ b/test/build.test.ts
@@ -1790,6 +1790,36 @@ export const routes = { helper };
       aliasOutDirPath
     );
     await expectFileExists(`${aliasOutDirPath}/index.d.ts`);
+
+    // A package entry field wins over "index", so the declarations must describe the same source the
+    // bundler picks; resolving to "index.ts" here would silently describe the wrong file.
+    await fs.promises.writeFile(`${fixtureDirPath}/src/folder/package.json`, JSON.stringify({ main: './entry.ts' }));
+    await fs.promises.writeFile(`${fixtureDirPath}/src/folder/entry.ts`, 'export const fromEntry: number = 3;\n');
+    const packageEntryOutDirPath = '.tmp/test-fixtures/lib-resolved-input-package-entry';
+    await buildWithPackagePath(
+      fixtureDirPath,
+      'lib',
+      '--declaration-only',
+      '--input',
+      `${fixtureDirPath}/src/folder`,
+      '--out-dir',
+      packageEntryOutDirPath
+    );
+    expect(fs.readdirSync(`${packageEntryOutDirPath}/folder`)).toEqual(['entry.d.ts']);
+
+    // An unusable entry field falls back to "index" instead of failing, as the bundler does.
+    await fs.promises.writeFile(`${fixtureDirPath}/src/folder/package.json`, '{ "main": ');
+    const brokenEntryOutDirPath = '.tmp/test-fixtures/lib-resolved-input-broken-entry';
+    await buildWithPackagePath(
+      fixtureDirPath,
+      'lib',
+      '--declaration-only',
+      '--input',
+      `${fixtureDirPath}/src/folder`,
+      '--out-dir',
+      brokenEntryOutDirPath
+    );
+    await expectFileExists(`${brokenEntryOutDirPath}/folder/index.d.ts`);
   });
 
   it('functions fails on conflicting entry names instead of silently dropping one', async () => {


### PR DESCRIPTION
…puts

`--input` paths were written verbatim into the generated tsconfig's `files`,
so entries the bundler resolves but `tsc`/`tsgo` cannot take literally failed
during declaration generation: a directory input raised TS6231 and a `.js`
specifier aliased to a `.ts` source raised TS6504.

Resolve each declaration input to the source file it refers to, applying the
bundler's `extensions` / `extensionAlias` candidates and directory -> `index`
resolution. The bundler still receives the literal paths, since resolving them
would change functions entry names and bypass `package.json` entry fields.

The new `inputResolver` module also becomes the single source of truth for the
bundler's resolve configuration, replacing the lossy `isBundlerResolvablePath`
copy that could drift from it.

Closes #671

Co-authored-by: WillBooster (Claude Code) <agent@willbooster.com>Close #<IssueNumber>

## Self Check

- [ ] I've confirmed `All checks have passed` on PR page. (You may leave this box unchecked due to long workflows.)
  - PR title follows [Angular's commit message format](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#-commit-message-format).
    - PR title doesn't have `WIP:`.
  - All tests are passed.
    - Test command (e.g., `yarn test`) is passed.
    - Lint command (e.g., `yarn lint`) is passed.
- [ ] I've reviewed my changes on PR's diff view.

<!-- Please add screenshots if you modify the UI.
| Current                  | In coming                |
| ------------------------ | ------------------------ |
| <img src="" width="400"> | <img src="" width="400"> |
-->
