### PR TITLE
feat!: remove .env.example support

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "@babel/preset-env": "8.0.2",
         "@babel/preset-react": "8.0.1",
         "@babel/preset-typescript": "8.0.1",
-        "@willbooster/shared-lib-node": "10.1.0",
+        "@willbooster/shared-lib-node": "11.0.0",
         "magic-string": "0.30.21",
         "oxc-parser": "0.139.0",
         "rolldown": "1.1.5",
@@ -29,7 +29,7 @@
         "@types/yargs": "17.0.35",
         "@willbooster/oxfmt-config": "1.2.2",
         "@willbooster/oxlint-config": "1.4.8",
-        "@willbooster/wb": "15.3.0",
+        "@willbooster/wb": "17.0.0",
         "conventional-changelog-conventionalcommits": "10.2.1",
         "lefthook": "2.1.10",
         "oxfmt": "0.59.0",
@@ -619,9 +619,9 @@
 
     "@willbooster/oxlint-config": ["@willbooster/oxlint-config@1.4.8", "", { "peerDependencies": { "oxlint": ">=1.60.0", "oxlint-tsgolint": ">=0.18.1" } }, "sha512-i3WWcAc1N6QzA91321dJFGUxXYuuXG4bj12pKlyjCmQRqrulvshFW35PUcaRdw1pVr7I7zHEGK1WUIjbkBd3Vg=="],
 
-    "@willbooster/shared-lib-node": ["@willbooster/shared-lib-node@10.1.0", "", { "dependencies": { "@types/yargs": "17.0.35", "dotenv": "17.4.2", "dotenv-expand": "13.0.0", "fast-glob": "3.3.3" } }, "sha512-sOxmqZs5xrn5UOo8+wZz4tONZZgSc3G4g0CC769o2eFR5ooxXN5pVkvhLPU6v+JYGrGW3ytV5Uaa7aso0NEAFQ=="],
+    "@willbooster/shared-lib-node": ["@willbooster/shared-lib-node@11.0.0", "", { "dependencies": { "@types/yargs": "17.0.35", "dotenv": "17.4.2", "dotenv-expand": "13.0.0", "fast-glob": "3.3.3" } }, "sha512-vObzQvceHQlxswMpdQJsrwT+ZnZlgq8f2LdaCtlywl32F6ePl/4fH1EoySXeM8/jVp4p7uq5fzSGjaIpfaP94w=="],
 
-    "@willbooster/wb": ["@willbooster/wb@15.3.0", "", { "dependencies": { "chalk": "5.6.2", "dotenv": "17.4.2", "dotenv-expand": "13.0.0", "fast-glob": "3.3.3", "fastest-levenshtein": "1.0.16", "globby": "16.2.0", "jsonc-parser": "3.3.1", "kill-port": "2.0.1", "minimal-promise-pool": "6.0.2", "semver": "7.8.5", "yargs": "18.0.0" }, "bin": { "wb": "bin/index.js" } }, "sha512-nksa8i1JA1gEzn9pYdJKGb2DBAZyny4CiRqzW2RbxIQJWZ4wvkvC3domlFf2UnpKKq6WRVdFBZEEZWnpeENJuQ=="],
+    "@willbooster/wb": ["@willbooster/wb@17.0.0", "", { "dependencies": { "chalk": "5.6.2", "dotenv": "17.4.2", "dotenv-expand": "13.0.0", "fast-glob": "3.3.3", "fastest-levenshtein": "1.0.16", "globby": "16.2.0", "jsonc-parser": "3.3.1", "kill-port": "2.0.1", "minimal-promise-pool": "6.0.2", "semver": "7.8.5", "yargs": "18.0.0" }, "bin": { "wb": "bin/index.js" } }, "sha512-0VcBCFxCadytrdFKmUzYwVd04VNufc2lLZ22tjnbqfYXxB46nMzxMYTvELwuAwyX1VhUO4FFqyPD48wq2V2juA=="],
 
     "agent-base": ["agent-base@9.0.0", "", {}, "sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA=="],
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@babel/preset-env": "8.0.2",
     "@babel/preset-react": "8.0.1",
     "@babel/preset-typescript": "8.0.1",
-    "@willbooster/shared-lib-node": "10.1.0",
+    "@willbooster/shared-lib-node": "11.0.0",
     "magic-string": "0.30.21",
     "oxc-parser": "0.139.0",
     "rolldown": "1.1.5",
@@ -54,7 +54,7 @@
     "@types/yargs": "17.0.35",
     "@willbooster/oxfmt-config": "1.2.2",
     "@willbooster/oxlint-config": "1.4.8",
-    "@willbooster/wb": "15.3.0",
+    "@willbooster/wb": "17.0.0",
     "conventional-changelog-conventionalcommits": "10.2.1",
     "lefthook": "2.1.10",
     "oxfmt": "0.59.0",
@@ -69,6 +69,7 @@
     "node": ">=24"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }


### PR DESCRIPTION
## Customer Summary

- build-ts no longer exposes the legacy `.env.example` validation option inherited from shared-lib-node.
- Existing `.env` loading and fnox-compatible workflows continue to work; only `.env.example` checking is removed.

## Technical Summary

- Update `@willbooster/shared-lib-node` from 10.1.0 to 11.0.0, which removes `--check-env` and `.env.example` validation.
- Update `@willbooster/wb` from 15.3.0 to 17.0.0 for the matching fnox-only toolchain.
- Pin the package publish registry to npmjs so Takumi Guard remains install-only during releases.

## Why

Current build-ts consumers already require fnox-compatible wb. Keeping the old `.env.example` check in the CLI adds an obsolete compatibility path and diverges from the shared toolchain.

## Testing

- `bun verify-full`
- `bun run start --help`
- Confirmed the CLI help contains neither `--check-env` nor `.env.example`
- Codex, Claude Code, and Antigravity review-fix: no concern
- Pull request CI passed
