### PR TITLE
test: cover .env file loading in run --env and build --auto-inline

### DIFF
--- a/test/unit/build.test.ts
+++ b/test/unit/build.test.ts
@@ -23,6 +23,45 @@ describe('build', { timeout: 60_000 }, () => {
     expect(indexJs).to.not.includes('process.env.A');
   });
 
+  it('app-node inlines env vars read from the package .env with --auto-inline', async () => {
+    const fixtureDirPath = '.tmp/test-fixtures/app-node-auto-inline';
+    await fs.promises.rm(fixtureDirPath, { recursive: true, force: true });
+    await fs.promises.mkdir(`${fixtureDirPath}/src`, { recursive: true });
+    await fs.promises.writeFile(`${fixtureDirPath}/package.json`, JSON.stringify({}));
+    // The name must be absent from fnox.toml and the ambient environment, otherwise this test would
+    // still pass if --auto-inline stopped reading .env files at all.
+    await fs.promises.writeFile(`${fixtureDirPath}/.env`, 'BUILD_TS_TEST_AUTO_INLINE=from-env-file\n');
+    await fs.promises.writeFile(
+      `${fixtureDirPath}/src/index.ts`,
+      `process.stdout.write(process.env.BUILD_TS_TEST_AUTO_INLINE ?? 'missing');\n`
+    );
+
+    await buildWithPackagePath(fixtureDirPath, 'app', '--auto-inline');
+    const indexJs = await readGeneratedCode(`${fixtureDirPath}/dist/index.js`);
+    expect(indexJs).to.not.includes('process.env.BUILD_TS_TEST_AUTO_INLINE');
+    // The built app runs without the variable in its environment, so only an inlined value can print it.
+    const execRet = await spawnAsync('node', ['dist/index.js'], { cwd: fixtureDirPath });
+    expect(execRet.status).toBe(0);
+    expect(execRet.stdout.trim()).toBe('from-env-file');
+  });
+
+  it('app-node keeps env vars unresolved without --auto-inline', async () => {
+    const fixtureDirPath = '.tmp/test-fixtures/app-node-no-auto-inline';
+    await fs.promises.rm(fixtureDirPath, { recursive: true, force: true });
+    await fs.promises.mkdir(`${fixtureDirPath}/src`, { recursive: true });
+    await fs.promises.writeFile(`${fixtureDirPath}/package.json`, JSON.stringify({}));
+    await fs.promises.writeFile(`${fixtureDirPath}/.env`, 'BUILD_TS_TEST_AUTO_INLINE=from-env-file\n');
+    await fs.promises.writeFile(
+      `${fixtureDirPath}/src/index.ts`,
+      `process.stdout.write(process.env.BUILD_TS_TEST_AUTO_INLINE ?? 'missing');\n`
+    );
+
+    await buildWithPackagePath(fixtureDirPath, 'app');
+    const execRet = await spawnAsync('node', ['dist/index.js'], { cwd: fixtureDirPath });
+    expect(execRet.status).toBe(0);
+    expect(execRet.stdout.trim()).toBe('missing');
+  });
+
   it('app-node removes only global console calls in valid statements', async () => {
     const fixtureDirPath = '.tmp/test-fixtures/app-node-console-scope';
     await fs.promises.rm(fixtureDirPath, { recursive: true, force: true });

--- a/test/unit/run.test.ts
+++ b/test/unit/run.test.ts
@@ -1,5 +1,7 @@
+import fs from 'node:fs';
+
 import { spawnAsync } from '@willbooster/shared-lib-node';
-import { describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 
 describe('run env.ts', { timeout: 60_000 }, () => {
   it.each([
@@ -37,6 +39,33 @@ describe('run hello.(c|m)ts', { timeout: 60_000 }, () => {
       expect(execRet.status).toBe(0);
     }
   );
+});
+
+describe('run with --env', { timeout: 60_000 }, () => {
+  // The name must be absent from fnox.toml and the ambient environment, otherwise these tests would
+  // still pass if --env stopped reading .env files at all.
+  const fixtureDirPath = '.tmp/test-fixtures/run-env-file';
+
+  beforeAll(async () => {
+    await fs.promises.rm(fixtureDirPath, { recursive: true, force: true });
+    await fs.promises.mkdir(fixtureDirPath, { recursive: true });
+    await fs.promises.writeFile(`${fixtureDirPath}/custom.env`, 'BUILD_TS_TEST_RUN_ENV=from-env-file\n');
+    await fs.promises.writeFile(
+      `${fixtureDirPath}/print.ts`,
+      `process.stdout.write(process.env.BUILD_TS_TEST_RUN_ENV ?? 'missing');\n`
+    );
+  });
+
+  it.each([
+    [['--env', `${fixtureDirPath}/custom.env`], 'from-env-file'],
+    [[], 'missing'],
+  ])('%s', async (options, expectedStdout) => {
+    const execRet = await spawnAsync('bun', ['run', 'start-prod', 'run', `${fixtureDirPath}/print.ts`, ...options], {
+      env: getTestEnvironment(),
+    });
+    expect(execRet.stdout.trim().split('\n').at(-1)?.trim()).toBe(expectedStdout);
+    expect(execRet.status).toBe(0);
+  });
 });
 
 function getTestEnvironment(): NodeJS.ProcessEnv {


### PR DESCRIPTION
## Customer Summary

- No behavior change; this adds test coverage only.
- Protects `build-ts`'s `.env` file support so a future refactor cannot silently drop it.

## Technical Summary

- `test/unit/run.test.ts`: new `run with --env` suite that writes `.tmp/test-fixtures/run-env-file/custom.env` defining `BUILD_TS_TEST_RUN_ENV`, then asserts `run <script> --env <file>` exposes it to the child process. A negative control without `--env` asserts the variable stays unset.
- `test/unit/build.test.ts`: new cases that write a package-local `.env` defining `BUILD_TS_TEST_AUTO_INLINE`, then assert `build app --auto-inline` inlines it (the generated code no longer mentions `process.env.BUILD_TS_TEST_AUTO_INLINE`, and the built app prints the value even though the variable is absent from its own environment). A negative control asserts the default (`--auto-inline` off) leaves the reference unresolved.
- Both new variable names are deliberately absent from `fnox.toml` and the ambient environment; comments in the tests record why.

## Why

- The existing env tests assert on `A`, which `fnox.toml` defines. They do exercise env loading in general, but they pass whether the value arrives from a `.env` file or from fnox — so the `.env`-file reading path specifically had no test that would fail if it broke.
- Notably, `test/unit/run.test.ts` already had a `--env .env` case, but there is no root `.env` in this repository, so that case never read a file.
- The one `.env` fixture that used to exist (`test/fixtures/app-node/.env`, removed by wbfy in #681) was already dead: `auto-inline` defaults to `false` and the `app-node` test only passes `--inline A`.

## Testing

- `bun verify-full` — passes (type check clean, 4 test files / 36 tests, up from 32).
- Mutation-checked the new tests: temporarily stubbed `loadEnvironmentVariablesWithCache` in `src/env.ts` to return `{}`, confirmed both new positive cases fail (`expected 'missing' to be 'from-env-file'` and `expected ... to not include 'process.env.BUILD_TS_TEST_AUTO_INLINE'`), then reverted. Without this check the tests could have passed vacuously.

## Notes

- Fixtures live under `.tmp/`, so the `.env*` gitignore rule added in #681 is not a problem. The `run` fixture is named `custom.env` rather than `.env` on purpose, so the test proves `--env` reads the file it is given rather than picking one up via the default cascade.
